### PR TITLE
Replaced generic types with the concrete type `NodeData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Changed
 - Simplified `Node::has_text`.
+- Removed unused generic types from structures, simplifying code and improving readability without affecting the public API.
 
 ### Added
 - Added `Selection::filter` , `Selection::filter_matcher` and `Selection::try_filter` methods that filter a current selection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Changed
 - Simplified `Node::has_text`.
-- Removed unused generic types from structures, simplifying code and improving readability without affecting the public API.
+- Replaced generic types with the concrete type `NodeData`, simplifying code and improving readability without affecting the public API.
 
 ### Added
 - Added `Selection::filter` , `Selection::filter_matcher` and `Selection::try_filter` methods that filter a current selection.

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::matcher::{MatchScope, Matcher, Matches};
-use crate::node::{Element, InnerNode, NodeData, NodeId, NodeRef};
+use crate::node::{Element, TreeNode, NodeData, NodeId, NodeRef};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
 pub struct Document {
@@ -393,7 +393,7 @@ impl TreeSink for Document {
     }
 }
 
-fn append_to_existing_text(prev: &mut InnerNode, text: &str) -> bool {
+fn append_to_existing_text(prev: &mut TreeNode, text: &str) -> bool {
     match prev.data {
         NodeData::Text { ref mut contents } => {
             contents.push_slice(text);

--- a/src/document.rs
+++ b/src/document.rs
@@ -17,7 +17,7 @@ use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
 pub struct Document {
     /// The document's dom tree.
-    pub tree: Tree<NodeData>,
+    pub tree: Tree,
 
     /// Errors that occurred during parsing.
     pub errors: RefCell<Vec<Cow<'static, str>>>,
@@ -74,7 +74,7 @@ impl Document {
 impl Document {
     /// Return the underlying root document node.
     #[inline]
-    pub fn root(&self) -> NodeRef<NodeData> {
+    pub fn root(&self) -> NodeRef {
         self.tree.root()
     }
 
@@ -393,7 +393,7 @@ impl TreeSink for Document {
     }
 }
 
-fn append_to_existing_text(prev: &mut InnerNode<NodeData>, text: &str) -> bool {
+fn append_to_existing_text(prev: &mut InnerNode, text: &str) -> bool {
     match prev.data {
         NodeData::Text { ref mut contents } => {
             contents.push_slice(text);

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -12,7 +12,7 @@ fn fix_id(id: Option<NodeId>, offset: usize) -> Option<NodeId> {
 }
 
 /// fixes node ids
-fn fix_node<T: Debug>(n: &mut InnerNode<T>, offset: usize) {
+fn fix_node(n: &mut InnerNode, offset: usize) {
     n.id = n.id.map(|id| NodeId::new(id.value + offset));
     n.prev_sibling = n.prev_sibling.map(|id| NodeId::new(id.value + offset));
     n.next_sibling = n.next_sibling.map(|id| NodeId::new(id.value + offset));
@@ -21,17 +21,17 @@ fn fix_node<T: Debug>(n: &mut InnerNode<T>, offset: usize) {
 }
 
 /// An implementation of arena-tree.
-pub struct Tree<T> {
-    pub(crate) nodes: RefCell<Vec<InnerNode<T>>>,
+pub struct Tree {
+    pub(crate) nodes: RefCell<Vec<InnerNode>>,
 }
 
-impl<T: Debug> Debug for Tree<T> {
+impl Debug for Tree {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Tree").finish()
     }
 }
 
-impl<T: Clone> Clone for Tree<T> {
+impl Clone for Tree {
     fn clone(&self) -> Self {
         let nodes = self.nodes.borrow();
         Self {
@@ -40,7 +40,7 @@ impl<T: Clone> Clone for Tree<T> {
     }
 }
 
-impl Tree<NodeData> {
+impl Tree {
     /// Creates a new element with the given name.
     pub fn new_element(&self, name: &str) -> Node {
         let name = QualName::new(None, ns!(), LocalName::from(name));
@@ -65,7 +65,7 @@ impl Tree<NodeData> {
     }
 }
 
-impl<T: Debug> Tree<T> {
+impl Tree {
     /// Returns the root node.
     pub fn root_id(&self) -> NodeId {
         NodeId { value: 0 }
@@ -73,14 +73,14 @@ impl<T: Debug> Tree<T> {
 
     /// Creates a new tree with the given root.
     /// `T` is [`NodeData`].
-    pub fn new(root: T) -> Self {
+    pub fn new(root: NodeData) -> Self {
         let root_id = NodeId::new(0);
         Self {
             nodes: RefCell::new(vec![InnerNode::new(root_id, root)]),
         }
     }
     /// Creates a new node with the given data.
-    pub fn create_node(&self, data: T) -> NodeId {
+    pub fn create_node(&self, data: NodeData) -> NodeId {
         let mut nodes = self.nodes.borrow_mut();
         let new_child_id = NodeId::new(nodes.len());
 
@@ -89,7 +89,7 @@ impl<T: Debug> Tree<T> {
     }
 
     /// Gets node by id
-    pub fn get(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn get(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value).map(|_| NodeRef {
             id: *id,
@@ -99,7 +99,7 @@ impl<T: Debug> Tree<T> {
     }
 
     /// Gets node by id
-    pub fn get_unchecked(&self, id: &NodeId) -> NodeRef<T> {
+    pub fn get_unchecked(&self, id: &NodeId) -> NodeRef {
         NodeRef {
             id: *id,
             tree: self,
@@ -107,7 +107,7 @@ impl<T: Debug> Tree<T> {
     }
 
     /// Gets the root node
-    pub fn root(&self) -> NodeRef<T> {
+    pub fn root(&self) -> NodeRef {
         self.get_unchecked(&NodeId::new(0))
     }
 
@@ -118,8 +118,8 @@ impl<T: Debug> Tree<T> {
     /// * `max_depth` - The maximum depth of the ancestors. If `None`, or Some(0) the maximum depth is unlimited.
     ///
     /// # Returns
-    /// `Vec<NodeRef<T>>` A vector of ancestors nodes.
-    pub fn ancestors_of(&self, id: &NodeId, max_depth: Option<usize>) -> Vec<NodeRef<T>> {
+    /// `Vec<NodeRef>` A vector of ancestors nodes.
+    pub fn ancestors_of(&self, id: &NodeId, max_depth: Option<usize>) -> Vec<NodeRef> {
         self.ancestor_ids_of_it(id, max_depth)
             .map(|id| NodeRef::new(id, self))
             .collect()
@@ -151,7 +151,7 @@ impl<T: Debug> Tree<T> {
         &self,
         id: &NodeId,
         max_depth: Option<usize>,
-    ) -> AncestorNodes<'_, T> {
+    ) -> AncestorNodes<'_> {
         ancestor_nodes(self.nodes.borrow(), id, max_depth)
     }
 
@@ -164,7 +164,7 @@ impl<T: Debug> Tree<T> {
     /// # Returns
     ///
     /// `Vec<NodeRef<T>>` A vector of children nodes.
-    pub fn children_of(&self, id: &NodeId) -> Vec<NodeRef<T>> {
+    pub fn children_of(&self, id: &NodeId) -> Vec<NodeRef> {
         child_nodes(self.nodes.borrow(), id)
             .map(move |id| NodeRef::new(id, self))
             .collect()
@@ -175,7 +175,7 @@ impl<T: Debug> Tree<T> {
     /// # Arguments
     ///
     /// * `id` - The id of the node.
-    pub fn child_ids_of_it(&self, id: &NodeId) -> ChildNodes<'_, T> {
+    pub fn child_ids_of_it(&self, id: &NodeId) -> ChildNodes<'_> {
         child_nodes(self.nodes.borrow(), id)
     }
 
@@ -189,42 +189,42 @@ impl<T: Debug> Tree<T> {
     }
 
     /// Gets the first child node of a node by id
-    pub fn first_child_of(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn first_child_of(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value)?;
         node.first_child.map(|id| NodeRef { id, tree: self })
     }
 
     /// Gets the last child node of a node by id
-    pub fn last_child_of(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn last_child_of(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value)?;
         node.last_child.map(|id| NodeRef { id, tree: self })
     }
 
     /// Gets the parent node of a node by id
-    pub fn parent_of(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn parent_of(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value)?;
         node.parent.map(|id| NodeRef { id, tree: self })
     }
 
     /// Gets the previous sibling node of a node by id
-    pub fn prev_sibling_of(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn prev_sibling_of(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value)?;
         node.prev_sibling.map(|id| NodeRef { id, tree: self })
     }
 
     /// Gets the next sibling node of a node by id
-    pub fn next_sibling_of(&self, id: &NodeId) -> Option<NodeRef<T>> {
+    pub fn next_sibling_of(&self, id: &NodeId) -> Option<NodeRef> {
         let nodes = self.nodes.borrow();
         let node = nodes.get(id.value)?;
         node.next_sibling.map(|id| NodeRef { id, tree: self })
     }
 
     /// Creates a new element from data  and appends it to a node by id
-    pub fn append_child_data_of(&self, id: &NodeId, data: T) {
+    pub fn append_child_data_of(&self, id: &NodeId, data: NodeData) {
         let mut nodes = self.nodes.borrow_mut();
 
         let last_child_id = nodes.get(id.value).and_then(|node| node.last_child);
@@ -276,7 +276,7 @@ impl<T: Debug> Tree<T> {
     }
 
     /// Appends children nodes from another tree. Another tree is a tree from document fragment.
-    pub fn append_children_from_another_tree(&self, id: &NodeId, tree: Tree<T>) {
+    pub fn append_children_from_another_tree(&self, id: &NodeId, tree: Tree) {
         let mut nodes = self.nodes.borrow_mut();
         let mut new_nodes = tree.nodes.into_inner();
         assert!(
@@ -353,7 +353,7 @@ impl<T: Debug> Tree<T> {
         nodes.extend(new_nodes);
     }
 
-    pub fn append_prev_siblings_from_another_tree(&self, id: &NodeId, tree: Tree<T>) {
+    pub fn append_prev_siblings_from_another_tree(&self, id: &NodeId, tree: Tree) {
         let mut nodes = self.nodes.borrow_mut();
         let mut new_nodes = tree.nodes.into_inner();
         assert!(
@@ -555,7 +555,7 @@ impl<T: Debug> Tree<T> {
     /// A helper function to get the node from the tree and apply a function to it.
     pub fn query_node<F, B>(&self, id: &NodeId, f: F) -> Option<B>
     where
-        F: FnOnce(&InnerNode<T>) -> B,
+        F: FnOnce(&InnerNode) -> B,
     {
         let nodes = self.nodes.borrow();
         nodes.get(id.value).map(f)
@@ -565,7 +565,7 @@ impl<T: Debug> Tree<T> {
     /// Accepts a default value to return for a case if the node doesn't exist.
     pub fn query_node_or<F, B>(&self, id: &NodeId, default: B, f: F) -> B
     where
-        F: FnOnce(&InnerNode<T>) -> B,
+        F: FnOnce(&InnerNode) -> B,
     {
         let nodes = self.nodes.borrow();
         nodes.get(id.value).map_or(default, f)
@@ -574,7 +574,7 @@ impl<T: Debug> Tree<T> {
     /// A helper function to get the node from the tree and apply a function to it that modifies it.
     pub fn update_node<F, B>(&self, id: &NodeId, f: F) -> Option<B>
     where
-        F: FnOnce(&mut InnerNode<T>) -> B,
+        F: FnOnce(&mut InnerNode) -> B,
     {
         let mut nodes = self.nodes.borrow_mut();
         let node = nodes.get_mut(id.value)?;
@@ -586,7 +586,7 @@ impl<T: Debug> Tree<T> {
     /// Possibly will be removed in the future.
     pub fn compare_node<F, B>(&self, a: &NodeId, b: &NodeId, f: F) -> Option<B>
     where
-        F: FnOnce(&InnerNode<T>, &InnerNode<T>) -> B,
+        F: FnOnce(&InnerNode, &InnerNode) -> B,
     {
         let nodes = self.nodes.borrow();
         let node_a = nodes.get(a.value)?;

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -8,7 +8,7 @@ use selectors::{context, matching, visitor, Element};
 
 use crate::css::{CssLocalName, CssString};
 use crate::entities::NodeIdSet;
-use crate::node::{NodeData, NodeRef};
+use crate::node::NodeRef;
 
 /// CSS selector.
 #[derive(Clone, Debug)]
@@ -93,8 +93,8 @@ impl<'a, T> Matches<'a, T> {
     }
 }
 
-impl<'a, 'b> Iterator for Matches<'a, NodeRef<'b, NodeData>> {
-    type Item = NodeRef<'b, NodeData>;
+impl<'a, 'b> Iterator for Matches<'a, NodeRef<'b>> {
+    type Item = NodeRef<'b>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/src/node.rs
+++ b/src/node.rs
@@ -7,7 +7,7 @@ mod serializing;
 
 use std::fmt::Debug;
 
-pub use inner::InnerNode;
+pub use inner::TreeNode;
 pub use iters::{ancestor_nodes, child_nodes, AncestorNodes, ChildNodes};
 pub use node_data::{Element, NodeData};
 pub use node_ref::{Node, NodeRef};

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -4,19 +4,19 @@ use super::node_data::{Element, NodeData};
 use crate::NodeId;
 
 /// The inner node is a [`crate::Tree`] node.
-pub struct InnerNode<T> {
+pub struct InnerNode {
     pub id: Option<NodeId>,
     pub parent: Option<NodeId>,
     pub prev_sibling: Option<NodeId>,
     pub next_sibling: Option<NodeId>,
     pub first_child: Option<NodeId>,
     pub last_child: Option<NodeId>,
-    pub data: T,
+    pub data: NodeData,
 }
 
-impl<T> InnerNode<T> {
+impl InnerNode {
     /// Creates a new inner node.
-    pub(crate) fn new(id: NodeId, data: T) -> Self {
+    pub(crate) fn new(id: NodeId, data: NodeData) -> Self {
         InnerNode {
             id: Some(id),
             parent: None,
@@ -29,7 +29,7 @@ impl<T> InnerNode<T> {
     }
 }
 
-impl<T: Debug> Debug for InnerNode<T> {
+impl Debug for InnerNode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Node")
             .field("id", &self.id)
@@ -43,7 +43,7 @@ impl<T: Debug> Debug for InnerNode<T> {
     }
 }
 
-impl InnerNode<NodeData> {
+impl InnerNode {
     /// Checks if the node is a document node.
     pub fn is_document(&self) -> bool {
         matches!(self.data, NodeData::Document)
@@ -93,7 +93,7 @@ impl InnerNode<NodeData> {
     }
 }
 
-impl<T: Clone> Clone for InnerNode<T> {
+impl Clone for InnerNode {
     fn clone(&self) -> Self {
         Self {
             id: self.id,

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -3,8 +3,9 @@ use std::fmt::{self, Debug};
 use super::node_data::{Element, NodeData};
 use crate::NodeId;
 
+
 /// The inner node is a [`crate::Tree`] node.
-pub struct InnerNode {
+pub struct TreeNode {
     pub id: Option<NodeId>,
     pub parent: Option<NodeId>,
     pub prev_sibling: Option<NodeId>,
@@ -14,10 +15,10 @@ pub struct InnerNode {
     pub data: NodeData,
 }
 
-impl InnerNode {
+impl TreeNode {
     /// Creates a new inner node.
     pub(crate) fn new(id: NodeId, data: NodeData) -> Self {
-        InnerNode {
+        TreeNode {
             id: Some(id),
             parent: None,
             prev_sibling: None,
@@ -29,7 +30,7 @@ impl InnerNode {
     }
 }
 
-impl Debug for InnerNode {
+impl Debug for TreeNode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Node")
             .field("id", &self.id)
@@ -43,7 +44,7 @@ impl Debug for InnerNode {
     }
 }
 
-impl InnerNode {
+impl TreeNode {
     /// Checks if the node is a document node.
     pub fn is_document(&self) -> bool {
         matches!(self.data, NodeData::Document)
@@ -93,7 +94,7 @@ impl InnerNode {
     }
 }
 
-impl Clone for InnerNode {
+impl Clone for TreeNode {
     fn clone(&self) -> Self {
         Self {
             id: self.id,

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -1,11 +1,11 @@
 use std::cell::Ref;
 
-use super::inner::InnerNode;
+use super::inner::TreeNode;
 use super::NodeId;
 
 /// An iterator over the children of a node.
 pub struct ChildNodes<'a> {
-    nodes: Ref<'a, Vec<InnerNode>>,
+    nodes: Ref<'a, Vec<TreeNode>>,
     next_child_id: Option<NodeId>,
 }
 
@@ -20,7 +20,7 @@ impl<'a> ChildNodes<'a> {
     /// # Returns
     ///
     /// `ChildNodes<'a>`
-    pub fn new(nodes: Ref<'a, Vec<InnerNode>>, node_id: &NodeId) -> Self {
+    pub fn new(nodes: Ref<'a, Vec<TreeNode>>, node_id: &NodeId) -> Self {
         let first_child = nodes
             .get(node_id.value)
             .map(|node| node.first_child)
@@ -58,13 +58,13 @@ impl<'a> Iterator for ChildNodes<'a> {
 /// # Returns
 ///
 /// `ChildNodes<'a, T>`
-pub fn child_nodes<'a>(nodes: Ref<'a, Vec<InnerNode>>, id: &NodeId) -> ChildNodes<'a> {
+pub fn child_nodes<'a>(nodes: Ref<'a, Vec<TreeNode>>, id: &NodeId) -> ChildNodes<'a> {
     ChildNodes::new(nodes, id)
 }
 
 /// An iterator over the ancestors of a node.
 pub struct AncestorNodes<'a> {
-    nodes: Ref<'a, Vec<InnerNode>>,
+    nodes: Ref<'a, Vec<TreeNode>>,
     next_parent_id: Option<NodeId>,
     max_depth: Option<usize>,
     current_depth: usize,
@@ -83,7 +83,7 @@ impl<'a> AncestorNodes<'a> {
     ///
     /// `AncestorsIter<'a, T>`
     pub fn new(
-        nodes: Ref<'a, Vec<InnerNode>>,
+        nodes: Ref<'a, Vec<TreeNode>>,
         node_id: &NodeId,
         max_depth: Option<usize>,
     ) -> Self {
@@ -133,7 +133,7 @@ impl<'a> Iterator for AncestorNodes<'a> {
 ///
 /// `AncestorsIter<'a, T>`
 pub fn ancestor_nodes<'a>(
-    nodes: Ref<'a, Vec<InnerNode>>,
+    nodes: Ref<'a, Vec<TreeNode>>,
     id: &NodeId,
     max_depth: Option<usize>,
 ) -> AncestorNodes<'a> {

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -4,12 +4,12 @@ use super::inner::InnerNode;
 use super::NodeId;
 
 /// An iterator over the children of a node.
-pub struct ChildNodes<'a, T> {
-    nodes: Ref<'a, Vec<InnerNode<T>>>,
+pub struct ChildNodes<'a> {
+    nodes: Ref<'a, Vec<InnerNode>>,
     next_child_id: Option<NodeId>,
 }
 
-impl<'a, T> ChildNodes<'a, T> {
+impl<'a> ChildNodes<'a> {
     /// Creates a new `ChildNodes` iterator.
     ///
     /// # Arguments
@@ -19,8 +19,8 @@ impl<'a, T> ChildNodes<'a, T> {
     ///
     /// # Returns
     ///
-    /// `ChildNodes<'a, T>`
-    pub fn new(nodes: Ref<'a, Vec<InnerNode<T>>>, node_id: &NodeId) -> Self {
+    /// `ChildNodes<'a>`
+    pub fn new(nodes: Ref<'a, Vec<InnerNode>>, node_id: &NodeId) -> Self {
         let first_child = nodes
             .get(node_id.value)
             .map(|node| node.first_child)
@@ -33,7 +33,7 @@ impl<'a, T> ChildNodes<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for ChildNodes<'a, T> {
+impl<'a> Iterator for ChildNodes<'a> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -58,19 +58,19 @@ impl<'a, T> Iterator for ChildNodes<'a, T> {
 /// # Returns
 ///
 /// `ChildNodes<'a, T>`
-pub fn child_nodes<'a, T>(nodes: Ref<'a, Vec<InnerNode<T>>>, id: &NodeId) -> ChildNodes<'a, T> {
+pub fn child_nodes<'a>(nodes: Ref<'a, Vec<InnerNode>>, id: &NodeId) -> ChildNodes<'a> {
     ChildNodes::new(nodes, id)
 }
 
 /// An iterator over the ancestors of a node.
-pub struct AncestorNodes<'a, T> {
-    nodes: Ref<'a, Vec<InnerNode<T>>>,
+pub struct AncestorNodes<'a> {
+    nodes: Ref<'a, Vec<InnerNode>>,
     next_parent_id: Option<NodeId>,
     max_depth: Option<usize>,
     current_depth: usize,
 }
 
-impl<'a, T> AncestorNodes<'a, T> {
+impl<'a> AncestorNodes<'a> {
     /// Creates a new `AncestorsIter` iterator.
     ///
     /// # Arguments
@@ -83,7 +83,7 @@ impl<'a, T> AncestorNodes<'a, T> {
     ///
     /// `AncestorsIter<'a, T>`
     pub fn new(
-        nodes: Ref<'a, Vec<InnerNode<T>>>,
+        nodes: Ref<'a, Vec<InnerNode>>,
         node_id: &NodeId,
         max_depth: Option<usize>,
     ) -> Self {
@@ -98,7 +98,7 @@ impl<'a, T> AncestorNodes<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for AncestorNodes<'a, T> {
+impl<'a> Iterator for AncestorNodes<'a> {
     type Item = NodeId;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -132,10 +132,10 @@ impl<'a, T> Iterator for AncestorNodes<'a, T> {
 /// # Returns
 ///
 /// `AncestorsIter<'a, T>`
-pub fn ancestor_nodes<'a, T>(
-    nodes: Ref<'a, Vec<InnerNode<T>>>,
+pub fn ancestor_nodes<'a>(
+    nodes: Ref<'a, Vec<InnerNode>>,
     id: &NodeId,
     max_depth: Option<usize>,
-) -> AncestorNodes<'a, T> {
+) -> AncestorNodes<'a> {
     AncestorNodes::new(nodes, id, max_depth)
 }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -10,7 +10,7 @@ use tendril::StrTendril;
 use crate::Document;
 use crate::Tree;
 
-use super::inner::InnerNode;
+use super::inner::TreeNode;
 use super::node_data::NodeData;
 use super::serializing::SerializableNodeRef;
 use super::NodeId;
@@ -34,7 +34,7 @@ impl<'a> NodeRef<'a> {
     #[inline]
     pub fn query<F, B>(&self, f: F) -> Option<B>
     where
-        F: FnOnce(&InnerNode) -> B,
+        F: FnOnce(&TreeNode) -> B,
     {
         self.tree.query_node(&self.id, f)
     }
@@ -44,7 +44,7 @@ impl<'a> NodeRef<'a> {
     #[inline]
     pub fn query_or<F, B>(&self, default: B, f: F) -> B
     where
-        F: FnOnce(&InnerNode) -> B,
+        F: FnOnce(&TreeNode) -> B,
     {
         self.tree.query_node_or(&self.id, default, f)
     }
@@ -53,7 +53,7 @@ impl<'a> NodeRef<'a> {
     #[inline]
     pub fn update<F, B>(&self, f: F) -> Option<B>
     where
-        F: FnOnce(&mut InnerNode) -> B,
+        F: FnOnce(&mut TreeNode) -> B,
     {
         self.tree.update_node(&self.id, f)
     }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -16,17 +16,17 @@ use super::serializing::SerializableNodeRef;
 use super::NodeId;
 
 /// Alias for `NodeRef`.
-pub type Node<'a> = NodeRef<'a, NodeData>;
+pub type Node<'a> = NodeRef<'a>;
 
 #[derive(Clone, Debug)]
-pub struct NodeRef<'a, T> {
+pub struct NodeRef<'a> {
     pub id: NodeId,
-    pub tree: &'a Tree<T>,
+    pub tree: &'a Tree,
 }
 
-impl<'a, T: Debug> NodeRef<'a, T> {
+impl<'a> NodeRef<'a> {
     /// Creates a new node reference.
-    pub fn new(id: NodeId, tree: &'a Tree<T>) -> Self {
+    pub fn new(id: NodeId, tree: &'a Tree) -> Self {
         Self { id, tree }
     }
 
@@ -34,7 +34,7 @@ impl<'a, T: Debug> NodeRef<'a, T> {
     #[inline]
     pub fn query<F, B>(&self, f: F) -> Option<B>
     where
-        F: FnOnce(&InnerNode<T>) -> B,
+        F: FnOnce(&InnerNode) -> B,
     {
         self.tree.query_node(&self.id, f)
     }
@@ -44,7 +44,7 @@ impl<'a, T: Debug> NodeRef<'a, T> {
     #[inline]
     pub fn query_or<F, B>(&self, default: B, f: F) -> B
     where
-        F: FnOnce(&InnerNode<T>) -> B,
+        F: FnOnce(&InnerNode) -> B,
     {
         self.tree.query_node_or(&self.id, default, f)
     }
@@ -53,7 +53,7 @@ impl<'a, T: Debug> NodeRef<'a, T> {
     #[inline]
     pub fn update<F, B>(&self, f: F) -> Option<B>
     where
-        F: FnOnce(&mut InnerNode<T>) -> B,
+        F: FnOnce(&mut InnerNode) -> B,
     {
         self.tree.update_node(&self.id, f)
     }
@@ -150,12 +150,12 @@ impl<'a, T: Debug> NodeRef<'a, T> {
 
     /// Appends another tree to the selected node from another tree.
     #[inline]
-    pub fn append_children_from_another_tree(&self, tree: Tree<T>) {
+    pub fn append_children_from_another_tree(&self, tree: Tree) {
         self.tree.append_children_from_another_tree(&self.id, tree)
     }
 
     #[inline]
-    pub fn append_prev_siblings_from_another_tree(&self, tree: Tree<T>) {
+    pub fn append_prev_siblings_from_another_tree(&self, tree: Tree) {
         self.tree
             .append_prev_siblings_from_another_tree(&self.id, tree)
     }

--- a/src/node/serializing.rs
+++ b/src/node/serializing.rs
@@ -15,8 +15,8 @@ enum SerializeOp<'a> {
 /// Serializable wrapper of Node.
 pub struct SerializableNodeRef<'a>(Node<'a>);
 
-impl<'a> From<NodeRef<'a, NodeData>> for SerializableNodeRef<'a> {
-    fn from(h: NodeRef<'a, NodeData>) -> SerializableNodeRef {
+impl<'a> From<NodeRef<'a>> for SerializableNodeRef<'a> {
+    fn from(h: NodeRef<'a>) -> SerializableNodeRef<'a> {
         SerializableNodeRef(h)
     }
 }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -5,7 +5,7 @@ use tendril::StrTendril;
 
 use crate::document::Document;
 use crate::matcher::{MatchScope, Matcher, Matches};
-use crate::node::{Node, NodeData, NodeRef};
+use crate::node::{Node, NodeRef};
 
 /// Selection represents a collection of nodes matching some criteria. The
 /// initial Selection object can be created by using [`Document::select`], and then
@@ -21,8 +21,8 @@ impl<'a> From<Node<'a>> for Selection<'a> {
     }
 }
 
-impl<'a> From<Vec<NodeRef<'a, NodeData>>> for Selection<'a> {
-    fn from(nodes: Vec<NodeRef<'a, NodeData>>) -> Selection {
+impl<'a> From<Vec<NodeRef<'a>>> for Selection<'a> {
+    fn from(nodes: Vec<NodeRef<'a>>) -> Selection {
         Self { nodes }
     }
 }


### PR DESCRIPTION
Refactored the structures to replace generic types with the concrete type `NodeData`, as their functionality was fully implemented only for `NodeData`.
This change simplifies the code, improves readability and navigation, and does not affect the public API of the crate.