### PR TITLE
refactor `NodeRef` and `Node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Changed
 - Simplified `Node::has_text`.
 - Replaced generic types with the concrete type `NodeData`, simplifying code and improving readability without affecting the public API.
+- Replaced implementations for `Node` with implementations for `NodeRef`. `Node` is just an alias for `NodeRef`.
 
 ### Added
 - Added `Selection::filter` , `Selection::filter_matcher` and `Selection::try_filter` methods that filter a current selection.

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -5,7 +5,7 @@ use html5ever::LocalName;
 use html5ever::{namespace_url, ns, QualName};
 
 use crate::node::{ancestor_nodes, child_nodes, AncestorNodes, ChildNodes};
-use crate::node::{Element, TreeNode, Node, NodeData, NodeId, NodeRef};
+use crate::node::{Element, TreeNode, NodeData, NodeId, NodeRef};
 
 fn fix_id(id: Option<NodeId>, offset: usize) -> Option<NodeId> {
     id.map(|old| NodeId::new(old.value + offset))
@@ -42,7 +42,7 @@ impl Clone for Tree {
 
 impl Tree {
     /// Creates a new element with the given name.
-    pub fn new_element(&self, name: &str) -> Node {
+    pub fn new_element(&self, name: &str) -> NodeRef {
         let name = QualName::new(None, ns!(), LocalName::from(name));
         let el = Element::new(name.clone(), Vec::new(), None, false);
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -182,7 +182,7 @@ impl<'a> NodeRef<'a> {
     }
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     /// Parses given fragment html and appends its contents to the selected node.
     pub fn append_html<T>(&self, html: T)
     where
@@ -202,9 +202,9 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     /// Returns the next sibling, that is an [`NodeData::Element`] of the selected node.
-    pub fn next_element_sibling(&self) -> Option<Node<'a>> {
+    pub fn next_element_sibling(&self) -> Option<Self> {
         let nodes = self.tree.nodes.borrow();
         let mut node = nodes.get(self.id.value)?;
 
@@ -221,7 +221,7 @@ impl<'a> Node<'a> {
     }
 
     /// Returns the previous sibling, that is an [`NodeData::Element`] of the selected node.
-    pub fn prev_element_sibling(&self) -> Option<Node<'a>> {
+    pub fn prev_element_sibling(&self) -> Option<Self> {
         let nodes = self.tree.nodes.borrow();
         let mut node = nodes.get(self.id.value)?;
 
@@ -239,7 +239,7 @@ impl<'a> Node<'a> {
     }
 
     /// Returns the first child, that is an [`NodeData::Element`] of the selected node.
-    pub fn first_element_child(&self) -> Option<Node<'a>> {
+    pub fn first_element_child(&self) -> Option<Self> {
         let nodes = self.tree.nodes.borrow();
         let node = nodes.get(self.id.value)?;
         let mut next_child_id = node.first_child;
@@ -262,7 +262,7 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     /// Returns the name of the selected node if it is an [`NodeData::Element`] otherwise `None`.
     pub fn node_name(&self) -> Option<StrTendril> {
         let nodes = self.tree.nodes.borrow();
@@ -370,7 +370,7 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     /// Returns true if this node is a document.
     pub fn is_document(&self) -> bool {
         self.query_or(false, |node| node.is_document())
@@ -400,7 +400,7 @@ impl<'a> Node<'a> {
     }
 }
 
-impl<'a> Node<'a> {
+impl<'a> NodeRef<'a> {
     /// Returns the HTML representation of the DOM tree.
     /// Panics if serialization fails.
     pub fn html(&self) -> StrTendril {

--- a/src/node/selector.rs
+++ b/src/node/selector.rs
@@ -8,11 +8,11 @@ use selectors::parser::SelectorImpl;
 use selectors::OpaqueElement;
 
 use super::node_data::NodeData;
-use super::node_ref::Node;
+use super::NodeRef;
 use crate::css::CssLocalName;
 use crate::matcher::{InnerSelector, NonTSPseudoClass};
 
-impl<'a> selectors::Element for Node<'a> {
+impl<'a> selectors::Element for NodeRef<'a> {
     type Impl = InnerSelector;
 
     fn add_element_unique_hashes(&self, _filter: &mut selectors::bloom::BloomFilter) -> bool {

--- a/src/node/serializing.rs
+++ b/src/node/serializing.rs
@@ -5,7 +5,7 @@ use html5ever::serialize::{Serialize, Serializer};
 use html5ever::QualName;
 
 use super::node_data::NodeData;
-use super::node_ref::{Node, NodeRef};
+use super::node_ref::NodeRef;
 use super::NodeId;
 
 enum SerializeOp<'a> {
@@ -13,7 +13,7 @@ enum SerializeOp<'a> {
     Close(&'a QualName),
 }
 /// Serializable wrapper of Node.
-pub struct SerializableNodeRef<'a>(Node<'a>);
+pub struct SerializableNodeRef<'a>(NodeRef<'a>);
 
 impl<'a> From<NodeRef<'a>> for SerializableNodeRef<'a> {
     fn from(h: NodeRef<'a>) -> SerializableNodeRef<'a> {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -5,18 +5,18 @@ use tendril::StrTendril;
 
 use crate::document::Document;
 use crate::matcher::{MatchScope, Matcher, Matches};
-use crate::node::{Node, NodeRef};
+use crate::node::NodeRef;
 
 /// Selection represents a collection of nodes matching some criteria. The
 /// initial Selection object can be created by using [`Document::select`], and then
 /// manipulated using methods itself.
 #[derive(Debug, Clone, Default)]
 pub struct Selection<'a> {
-    pub(crate) nodes: Vec<Node<'a>>,
+    pub(crate) nodes: Vec<NodeRef<'a>>,
 }
 
-impl<'a> From<Node<'a>> for Selection<'a> {
-    fn from(node: Node<'a>) -> Selection {
+impl<'a> From<NodeRef<'a>> for Selection<'a> {
+    fn from(node: NodeRef<'a>) -> Selection {
         Self { nodes: vec![node] }
     }
 }
@@ -459,12 +459,12 @@ impl<'a> Selection<'a> {
     }
 
     /// Returns a slice of underlying nodes.
-    pub fn nodes(&self) -> &[Node<'a>] {
+    pub fn nodes(&self) -> &[NodeRef<'a>] {
         &self.nodes
     }
 
     /// Creates an iterator over these matched elements.
-    pub fn iter(&self) -> Selections<Node<'a>> {
+    pub fn iter(&self) -> Selections<NodeRef<'a>> {
         Selections::new(self.nodes.clone().into_iter())
     }
 
@@ -570,7 +570,7 @@ impl<'a> Selection<'a> {
     }
 
     /// Retrieves the underlying node at the specified index.
-    pub fn get(&self, index: usize) -> Option<&Node<'a>> {
+    pub fn get(&self, index: usize) -> Option<&NodeRef<'a>> {
         self.nodes.get(index)
     }
 }
@@ -586,7 +586,7 @@ impl<I> Selections<I> {
     }
 }
 
-impl<'a> Iterator for Selections<Node<'a>> {
+impl<'a> Iterator for Selections<NodeRef<'a>> {
     type Item = Selection<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -594,7 +594,7 @@ impl<'a> Iterator for Selections<Node<'a>> {
     }
 }
 
-impl<'a> DoubleEndedIterator for Selections<Node<'a>> {
+impl<'a> DoubleEndedIterator for Selections<NodeRef<'a>> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back().map(Selection::from)
     }


### PR DESCRIPTION
- `NodeRef` implements everything that `Node` implemented.
- `Node` is an alias of `NodeRef`.