### PR TITLE
src/node/id_provider.rs: added `NodeIdProvider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Added `Selection::filter_selection` method that filters a current selection with another selection.
 - Added `NodeRef::replace_with` method that allows to replace a node with another one.
 - Added `NodeRef::replace_with_html` method that allows to replace a node with a new node created from the given HTML.
+- Added `NodeIdProver` trait and implementations for `NodeRef` and `Node`. Which allows to call some node functions with a `&NodeRef` and `&NodeId`. 
+Previously these functions required `NodeId` as a parameter.
 
 ### Fixed
 - Fixed `Tree::append_prev_siblings_from_another_tree` method. It didn't assign `TreeNode.prev_sibling` properly.

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::matcher::{MatchScope, Matcher, Matches};
-use crate::node::{Element, TreeNode, NodeData, NodeId, NodeRef};
+use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
 #[derive(Clone)]

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -5,7 +5,7 @@ use html5ever::LocalName;
 use html5ever::{namespace_url, ns, QualName};
 
 use crate::node::{ancestor_nodes, child_nodes, AncestorNodes, ChildNodes};
-use crate::node::{Element, TreeNode, NodeData, NodeId, NodeRef};
+use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 
 fn fix_id(id: Option<NodeId>, offset: usize) -> Option<NodeId> {
     id.map(|old| NodeId::new(old.value + offset))
@@ -147,11 +147,7 @@ impl Tree {
     ///
     /// # Returns
     /// `AncestorNodes<'a, T>`
-    pub fn ancestor_ids_of_it(
-        &self,
-        id: &NodeId,
-        max_depth: Option<usize>,
-    ) -> AncestorNodes<'_> {
+    pub fn ancestor_ids_of_it(&self, id: &NodeId, max_depth: Option<usize>) -> AncestorNodes<'_> {
         ancestor_nodes(self.nodes.borrow(), id, max_depth)
     }
 
@@ -421,7 +417,7 @@ impl Tree {
                     i if i == TRUE_ROOT_ID => parent_id,
                     i => fix_id(Some(NodeId::new(i)), offset),
                 });
-            
+
             fix_node(node, offset);
 
             // Update first child's prev_sibling

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! HTML manipulation with CSS selectors.
 //!
 //! # Features
-//! 
+//!
 //! - Parse HTML documents and fragments
 //! - Query DOM elements using CSS selectors
 //! - Traverse the DOM tree (ancestors, parents, children, siblings)
@@ -28,5 +28,5 @@ pub use dom_tree::Tree;
 pub use matcher::Matcher;
 #[doc(hidden)]
 pub use node::SerializableNodeRef;
-pub use node::{Element, Node, NodeData, NodeId, NodeRef};
+pub use node::{Element, Node, NodeData, NodeId, NodeIdProver, NodeRef};
 pub use selection::Selection;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,3 +1,4 @@
+mod id_provider;
 mod inner;
 mod iters;
 mod node_data;
@@ -7,6 +8,7 @@ mod serializing;
 
 use std::fmt::Debug;
 
+pub use id_provider::NodeIdProver;
 pub use inner::TreeNode;
 pub use iters::{ancestor_nodes, child_nodes, AncestorNodes, ChildNodes};
 pub use node_data::{Element, NodeData};

--- a/src/node/id_provider.rs
+++ b/src/node/id_provider.rs
@@ -1,0 +1,19 @@
+use super::{node_ref::NodeRef, NodeId};
+
+/// A trait that provides the [`NodeId`]
+pub trait NodeIdProver {
+    /// Returns the [`NodeId`]
+    fn node_id(&self) -> &NodeId;
+}
+
+impl NodeIdProver for &NodeRef<'_> {
+    fn node_id(&self) -> &NodeId {
+        &self.id
+    }
+}
+
+impl NodeIdProver for &NodeId {
+    fn node_id(&self) -> Self {
+        self
+    }
+}

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use super::node_data::{Element, NodeData};
 use crate::NodeId;
 
-
 /// The inner node is a [`crate::Tree`] node.
 #[derive(Debug)]
 pub struct TreeNode {

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -82,11 +82,7 @@ impl<'a> AncestorNodes<'a> {
     /// # Returns
     ///
     /// `AncestorsIter<'a, T>`
-    pub fn new(
-        nodes: Ref<'a, Vec<TreeNode>>,
-        node_id: &NodeId,
-        max_depth: Option<usize>,
-    ) -> Self {
+    pub fn new(nodes: Ref<'a, Vec<TreeNode>>, node_id: &NodeId, max_depth: Option<usize>) -> Self {
         let next_parent_id = nodes.get(node_id.value).and_then(|node| node.parent);
 
         AncestorNodes {

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -55,8 +55,7 @@ pub static HEADING_CONTENTS: &str = r#"<!DOCTYPE html>
         </body>
     </html>"#;
 
-
-pub static  REPLACEMENT_CONTENTS: &str = r#"<!DOCTYPE html>
+pub static REPLACEMENT_CONTENTS: &str = r#"<!DOCTYPE html>
     <html lang="en">
         <head></head>
         <body>

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -76,7 +76,6 @@ fn test_set_element_html() {
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_change_parent_node() {
-
     let doc = Document::from(REPLACEMENT_CONTENTS);
 
     let origin_sel = doc.select_single("#origin");
@@ -98,9 +97,8 @@ fn test_change_parent_node() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_node_replace_with() {
-
-    // It's actually the same test as `test_change_parent_node`, 
+fn test_node_replace_with_by_node_id() {
+    // It's actually the same test as `test_change_parent_node`,
     // using `replace_with` instead of `append_prev_sibling` and `remove_from_parent`
     let doc = Document::from(REPLACEMENT_CONTENTS);
 
@@ -122,9 +120,32 @@ fn test_node_replace_with() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_node_replace_with_html() {
+fn test_node_replace_with_by_node() {
+    // It's actually the same test as `test_node_replace_with_by_node`,
+    // using but using &node instead of &node.id in node methods.
+    // which i find more readable
+    let doc = Document::from(REPLACEMENT_CONTENTS);
 
-    // It's actually the same test as `test_change_parent_node`, 
+    let origin_sel: dom_query::Selection<'_> = doc.select_single("#origin");
+    let origin_node: &dom_query::NodeRef<'_> = origin_sel.nodes().first().unwrap();
+
+    // create a new `p` element with id:
+    let p: dom_query::NodeRef<'_> = doc.tree.new_element("p");
+    p.set_attr("id", "outline");
+
+    // replacing origin_node with `p` node, detaching `origin_node` from the tree
+    origin_node.replace_with(&p);
+
+    // append `origin_node` it to the new `p` node
+    p.append_child(origin_node);
+
+    assert!(doc.select("#outline > #origin > #inline").exists());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_replace_with_html() {
+    // It's actually the same test as `test_change_parent_node`,
     // using `replace_with` instead of `append_prev_sibling` and `remove_from_parent`
     let doc = Document::from(REPLACEMENT_CONTENTS);
 
@@ -132,7 +153,7 @@ fn test_node_replace_with_html() {
     let origin_node = origin_sel.nodes().first().unwrap();
     // replacing origin_node with `p` node, detaching `origin_node` from the tree, origin node is detached
     origin_node.replace_with_html(r#"<p id="replaced"><span id="inline">Something</span></p>"#);
-    
+
     // checking if #replaced can be access as next sibling of #before-origin
     assert!(doc.select("#before-origin + #replaced > #inline").exists());
     // checking if #after-origin can be access after it's new previous sibling
@@ -142,7 +163,6 @@ fn test_node_replace_with_html() {
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_replace_with_reparent() {
-
     let doc = Document::from(REPLACEMENT_CONTENTS);
 
     let origin_sel = doc.select_single("#origin");
@@ -165,4 +185,3 @@ fn test_node_replace_with_reparent() {
     // #inline is a child of #outline now
     assert!(doc.select("#outline > #inline").exists());
 }
-

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -76,7 +76,6 @@ fn test_replace_with_selection() {
     assert!(sel.is("#nf6"));
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn remove_descendant_attributes() {


### PR DESCRIPTION
Since it’s more convenient to pass `&node` rather than `&node.id`, `NodeIdProvider` was added. Now, methods like `NodeRef::append_prev_sibling`, `NodeRef::append_child`, and `NodeRef::replace_with` accept either `&NodeRef` or `&NodeId`, improving readability.