### PR TITLE
Replace logic `Tree::append_prev_siblings_from_another_tree` and `Tree::append_children_from_another_tree` with `Tree::merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Previously these functions required `NodeId` as a parameter.
 - Fixed `Tree::append_prev_siblings_from_another_tree` method. It didn't assign `TreeNode.prev_sibling` properly.
 - Fixed `<NodeRef<'a> as selectors::Element>::is_empty` to correctly handle line breaks, whitespace, and ensure only elements pass the check.
 
-
+### Removed
+- Removed `Tree::append_children_from_another_tree` method.
+- Removed `Node::append_children_from_another_tree` method.
 
 ## [0.7.0] - 2024-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Simplified `Node::has_text`.
 - Replaced generic types with the concrete type `NodeData`, simplifying code and improving readability without affecting the public API.
 - Replaced implementations for `Node` with implementations for `NodeRef`. `Node` is just an alias for `NodeRef`.
+- Simplified internal logic of `Selection::replace_with_html`, `Selection::set_html`, 
+`Selection::append_html`, `Node::set_html`, `Node::append_html`, and `Node::replace_with_html` by using `Tree::merge`.
 
 ### Added
 - Added `Selection::filter` , `Selection::filter_matcher` and `Selection::try_filter` methods that filter a current selection.
@@ -18,6 +20,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 Previously these functions required `NodeId` as a parameter.
 - Added a new pseudo-class `:only-text` that allows selecting a node with no child elements except a single **text** child node.
 - Added the `NodeRef::set_text` method, which sets the text content of a node, replacing any existing content.
+- Added `NodeRef::append_prev_siblings` method, which allows to prepend other nodes and their siblings before the selected node.
 
 ### Fixed
 - Fixed `Tree::append_prev_siblings_from_another_tree` method. It didn't assign `TreeNode.prev_sibling` properly.
@@ -25,7 +28,9 @@ Previously these functions required `NodeId` as a parameter.
 
 ### Removed
 - Removed `Tree::append_children_from_another_tree` method.
+- Removed `Tree::append_prev_siblings_from_another_tree` method.
 - Removed `Node::append_children_from_another_tree` method.
+- Removed `Node::append_prev_siblings_from_another_tree` method.
 
 ## [0.7.0] - 2024-10-27
 

--- a/examples/pseudo_classes.rs
+++ b/examples/pseudo_classes.rs
@@ -4,12 +4,10 @@ fn main() {
     let html = include_str!("../test-pages/rustwiki_2024.html");
     let doc = Document::from(html);
 
-    // searching list items inside a `tr` element which has a `a` element 
+    // searching list items inside a `tr` element which has a `a` element
     // with title="Programming paradigm"
     let paradigm_selection =
-        doc.select(
-            r#"table tr:has(a[title="Programming paradigm"]) td.infobox-data ul > li"#
-        );
+        doc.select(r#"table tr:has(a[title="Programming paradigm"]) td.infobox-data ul > li"#);
 
     println!("Rust programming paradigms:");
     for item in paradigm_selection.iter() {
@@ -31,9 +29,7 @@ fn main() {
     // Since `foreign function interface` located in its own tag,
     // we have to use `:contains` pseudo class
     let links_selection =
-        doc.select(
-            r#"p:contains("Rust has a foreign function interface") a[href^="/"]"#
-        );
+        doc.select(r#"p:contains("Rust has a foreign function interface") a[href^="/"]"#);
 
     println!("Links in the FFI block:");
     for item in links_selection.iter() {
@@ -44,7 +40,7 @@ fn main() {
     // :only-text selects an element that contains only a single text node,
     // with no child elements.
     // It can be combined with other pseudo-classes to achieve more specific selections.
-    // For example, to select a <div> inside an <a> 
+    // For example, to select a <div> inside an <a>
     //that has no siblings and no child elements other than text.
     println!("Single <div> inside an <a> with text only:");
     for el in doc.select("a div:only-text:only-child").iter() {

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -8,13 +8,10 @@ use tendril::StrTendril;
 use crate::node::{ancestor_nodes, child_nodes, AncestorNodes, ChildNodes};
 use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 
-fn fix_id(id: Option<NodeId>, offset: usize) -> Option<NodeId> {
-    id.map(|old| NodeId::new(old.value + offset))
-}
-
 /// fixes node ids
 fn fix_node(n: &mut TreeNode, offset: usize) {
     n.id = n.id.map(|id| NodeId::new(id.value + offset));
+    n.parent = n.parent.map(|id| NodeId::new(id.value + offset));
     n.prev_sibling = n.prev_sibling.map(|id| NodeId::new(id.value + offset));
     n.next_sibling = n.next_sibling.map(|id| NodeId::new(id.value + offset));
     n.first_child = n.first_child.map(|id| NodeId::new(id.value + offset));
@@ -55,7 +52,7 @@ impl Tree {
     /// Creates a new text node with the given text, without parent
     pub fn new_text<T: Into<StrTendril>>(&self, text: T) -> NodeRef {
         let text = text.into();
-        let id = self.create_node(NodeData::Text{contents: text});
+        let id = self.create_node(NodeData::Text { contents: text });
         NodeRef { id, tree: self }
     }
 
@@ -279,95 +276,6 @@ impl Tree {
         }
     }
 
-    pub fn append_prev_siblings_from_another_tree(&self, id: &NodeId, tree: Tree) {
-        let mut nodes = self.nodes.borrow_mut();
-        let mut new_nodes = tree.nodes.into_inner();
-        assert!(
-            !new_nodes.is_empty(),
-            "Another tree should have at least one root node"
-        );
-        assert!(
-            !nodes.is_empty(),
-            "The tree should have at least one root node"
-        );
-
-        let offset = nodes.len();
-
-        // `parse_fragment` returns a document that looks like:
-        // <:root>                     id -> 0
-        //  <body>                     id -> 1
-        //      <html>                 id -> 2
-        //          things we need.
-        //      </html>
-        //  </body>
-        // <:root>
-        const TRUE_ROOT_ID: usize = 2;
-        let node_root_id = NodeId::new(TRUE_ROOT_ID);
-        let root = match new_nodes.get(node_root_id.value) {
-            Some(node) => node,
-            None => return,
-        };
-
-        let first_child_id = fix_id(root.first_child, offset);
-        let last_child_id = fix_id(root.last_child, offset);
-
-        let node = match nodes.get_mut(id.value) {
-            Some(node) => node,
-            None => return,
-        };
-
-        let prev_sibling_id = node.prev_sibling;
-        let parent_id = node.parent;
-
-        // Update node's previous sibling.
-        node.prev_sibling = last_child_id;
-
-        // Update prev sibling's next sibling
-        if let Some(prev_sibling_id) = prev_sibling_id {
-            if let Some(prev_sibling) = nodes.get_mut(prev_sibling_id.value) {
-                prev_sibling.next_sibling = first_child_id;
-            }
-
-        // Update parent's first child.
-        } else if let Some(parent_id) = parent_id {
-            if let Some(parent) = nodes.get_mut(parent_id.value) {
-                parent.first_child = first_child_id;
-            }
-        }
-
-        let mut last_valid_child = 0;
-        let mut first_valid_child = false;
-
-        // Fix nodes's ref id.
-        for (i, node) in new_nodes.iter_mut().enumerate() {
-            node.parent = node
-                .parent
-                .and_then(|old_parent_id| match old_parent_id.value {
-                    i if i < TRUE_ROOT_ID => None,
-                    i if i == TRUE_ROOT_ID => parent_id,
-                    i => fix_id(Some(NodeId::new(i)), offset),
-                });
-
-            fix_node(node, offset);
-
-            // Update first child's prev_sibling
-            if !first_valid_child && node.parent == parent_id {
-                first_valid_child = true;
-                node.prev_sibling = prev_sibling_id;
-            }
-
-            if node.parent == parent_id {
-                last_valid_child = i;
-            }
-        }
-
-        // Update last child's next_sibling.
-        new_nodes[last_valid_child].next_sibling = Some(*id);
-
-        // Put all the new nodes except the root node into the nodes.
-        nodes.extend(new_nodes);
-    }
-
     /// Remove a node from the its parent by id. The node remains in the tree.
     /// It is possible to assign it to another node in the tree after this operation.
     pub fn remove_from_parent(&self, id: &NodeId) {
@@ -523,11 +431,9 @@ impl Tree {
     }
 }
 
-
 impl Tree {
     /// Adds nodes from another tree to the current tree
     pub(crate) fn merge(&self, other: Tree) {
-
         // `parse_fragment` returns a document that looks like:
         // <:root>                     id -> 0
         //  <body>                     id -> 1
@@ -539,17 +445,22 @@ impl Tree {
         let mut nodes = self.nodes.borrow_mut();
 
         let mut other_nodes = other.nodes.into_inner();
+
         let offset = nodes.len();
         let skip: usize = 3;
         let id_offset = offset - skip;
-        for  node in other_nodes.iter_mut().skip(skip) {
-            fix_node(node, id_offset );
-            node.parent = node.parent.map(|id| NodeId::new(id.value + id_offset));
+
+        for node in other_nodes.iter_mut().skip(skip) {
+            fix_node(node, id_offset);
         }
-
         nodes.extend(other_nodes.into_iter().skip(skip));
+    }
 
-
+    /// Get the new id, that is not in the Tree.
+    /// 
+    /// This function doesn't add a new id. 
+    /// it is just a convenient wrapper to get the new id.
+    pub (crate) fn get_new_id(&self) -> NodeId {
+        NodeId::new(self.nodes.borrow().len())
     }
 }
-

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -23,7 +23,7 @@ fn fix_node(n: &mut TreeNode, offset: usize) {
 
 /// An implementation of arena-tree.
 pub struct Tree {
-    pub(crate) nodes: RefCell<Vec<TreeNode>>,
+    pub nodes: RefCell<Vec<TreeNode>>,
 }
 
 impl Debug for Tree {
@@ -600,3 +600,35 @@ impl Tree {
         Some(f(node_a, node_b))
     }
 }
+
+
+impl Tree {
+    /// Adds nodes from another tree to the current tree
+    pub(crate) fn merge(&self, other: Tree) {
+
+        // `parse_fragment` returns a document that looks like:
+        // <:root>                     id -> 0
+        //  <body>                     id -> 1
+        //      <html>                 id -> 2
+        //          things we need.
+        //      </html>
+        //  </body>
+        // <:root>
+        let mut nodes = self.nodes.borrow_mut();
+
+        let mut other_nodes = other.nodes.into_inner();
+        let offset = nodes.len();
+        let skip: usize = 3;
+        let id_offset = offset - skip;
+        for  node in other_nodes.iter_mut().skip(skip) {
+            fix_node(node, id_offset );
+            node.parent = node.parent.map(|id| NodeId::new(id.value + id_offset));
+        }
+
+
+        nodes.extend(other_nodes.into_iter().skip(skip));
+
+
+    }
+}
+

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -190,7 +190,10 @@ impl<'a> NodeRef<'a> {
         T: Into<StrTendril>,
     {
         let fragment = Document::fragment(html);
-        self.append_children_from_another_tree(fragment.tree);
+        let length = self.tree.nodes.borrow().len();
+        let new_node_id = NodeId::new(length);
+        self.tree.merge(fragment.tree);
+        self.append_child(&new_node_id); 
     }
 
     /// Parses given fragment html and sets its contents to the selected node.

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -152,10 +152,16 @@ impl<'a> NodeRef<'a> {
         self.tree.append_child_of(&self.id, id_provider.node_id())
     }
 
-    /// Appends another tree to the selected node from another tree.
+    /// Appends another node and it's siblings to the selected node.
     #[inline]
-    pub fn append_children_from_another_tree(&self, tree: Tree) {
-        self.tree.append_children_from_another_tree(&self.id, tree)
+    pub fn append_children<P: NodeIdProver>(&self, id_provider: P) {
+        let mut next_node = self.tree.get(id_provider.node_id());
+
+        while let Some(ref node) = next_node {
+            self.tree.append_child_of(&self.id, &node.id);
+            next_node = node.next_sibling();
+        }
+        
     }
 
     #[inline]
@@ -193,7 +199,7 @@ impl<'a> NodeRef<'a> {
         let length = self.tree.nodes.borrow().len();
         let new_node_id = NodeId::new(length);
         self.tree.merge(fragment.tree);
-        self.append_child(&new_node_id); 
+        self.append_children(&new_node_id); 
     }
 
     /// Parses given fragment html and sets its contents to the selected node.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,6 +6,7 @@ use tendril::StrTendril;
 use crate::document::Document;
 use crate::matcher::{MatchScope, Matcher, Matches};
 use crate::node::NodeRef;
+use crate::NodeId;
 
 /// Selection represents a collection of nodes matching some criteria. The
 /// initial Selection object can be created by using [`Document::select`], and then
@@ -319,6 +320,7 @@ impl<'a> Selection<'a> {
         T: Into<StrTendril>,
     {
         let dom = Document::fragment(html);
+        
 
         for (i, node) in self.nodes().iter().enumerate() {
             if i + 1 == self.size() {
@@ -351,15 +353,15 @@ impl<'a> Selection<'a> {
     where
         T: Into<StrTendril>,
     {
-        let dom = Document::fragment(html);
-
-        for (i, node) in self.nodes().iter().enumerate() {
-            if i + 1 == self.size() {
-                node.append_children_from_another_tree(dom.tree);
-                break;
-            } else {
-                node.append_children_from_another_tree(dom.tree.clone());
-            }
+        let fragment = Document::fragment(html);
+        
+        for node in self.nodes().iter() {
+                // length is an actual new node id of the first child node from the other tree
+                let length = node.tree.nodes.borrow().len();
+                let new_node_id = NodeId::new(length);
+                node.tree.merge(fragment.tree.clone());
+                node.append_child(&new_node_id); 
+            
         }
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,7 +6,6 @@ use tendril::StrTendril;
 use crate::document::Document;
 use crate::matcher::{MatchScope, Matcher, Matches};
 use crate::node::NodeRef;
-use crate::NodeId;
 
 /// Selection represents a collection of nodes matching some criteria. The
 /// initial Selection object can be created by using [`Document::select`], and then
@@ -319,16 +318,12 @@ impl<'a> Selection<'a> {
     where
         T: Into<StrTendril>,
     {
-        let dom = Document::fragment(html);
-        
+        let fragment = Document::fragment(html);
 
-        for (i, node) in self.nodes().iter().enumerate() {
-            if i + 1 == self.size() {
-                node.append_prev_siblings_from_another_tree(dom.tree);
-                break;
-            } else {
-                node.append_prev_siblings_from_another_tree(dom.tree.clone());
-            }
+        for node in self.nodes().iter() {
+            let new_node_id = node.tree.get_new_id();
+            node.tree.merge(fragment.tree.clone());
+            node.append_prev_siblings(&new_node_id);
         }
 
         self.remove()
@@ -354,14 +349,11 @@ impl<'a> Selection<'a> {
         T: Into<StrTendril>,
     {
         let fragment = Document::fragment(html);
-        
+
         for node in self.nodes().iter() {
-                // length is an actual new node id of the first child node from the other tree
-                let length = node.tree.nodes.borrow().len();
-                let new_node_id = NodeId::new(length);
-                node.tree.merge(fragment.tree.clone());
-                node.append_children(&new_node_id); 
-            
+            let new_node_id = node.tree.get_new_id();
+            node.tree.merge(fragment.tree.clone());
+            node.append_children(&new_node_id);
         }
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -360,7 +360,7 @@ impl<'a> Selection<'a> {
                 let length = node.tree.nodes.borrow().len();
                 let new_node_id = NodeId::new(length);
                 node.tree.merge(fragment.tree.clone());
-                node.append_child(&new_node_id); 
+                node.append_children(&new_node_id); 
             
         }
     }

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -65,3 +65,14 @@ pub static REPLACEMENT_CONTENTS: &str = r#"<!DOCTYPE html>
             </div>
         </body>
     </html>"#;
+
+pub static EMPTY_BLOCKS_CONTENTS: &str = r#"<!DOCTYPE html>
+    <html>
+        <head></head>
+        <body>
+            <div id="main">
+                <div></div>
+                <div></div>
+            </div>
+        </body>
+    </html>"#;

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -3,7 +3,6 @@ mod data;
 use data::REPLACEMENT_CONTENTS;
 use dom_query::Document;
 
-use wasm_bindgen_test::__rt::node;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -210,7 +210,6 @@ fn test_node_replace_text_node() {
     assert_eq!(doc.select("#main > p").inner_html(), "Some text".into());
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_set_text() {
@@ -227,10 +226,9 @@ fn test_node_set_text() {
     let doc = Document::from(content);
     let content_sel = doc.select("#content");
     let content_node = content_sel.nodes().first().unwrap();
-    
+
     let text = "New content";
     content_node.set_text(text);
     assert_eq!(content_node.inner_html(), text.into());
     assert_eq!(doc.select("#content").inner_html(), text.into());
-    
 }

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -3,6 +3,7 @@ mod data;
 use data::REPLACEMENT_CONTENTS;
 use dom_query::Document;
 
+use wasm_bindgen_test::__rt::node;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 

--- a/tests/pseudo-classes.rs
+++ b/tests/pseudo-classes.rs
@@ -208,7 +208,6 @@ fn test_where() {
     assert_eq!(where_sel.length(), 3);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_empty() {
@@ -299,7 +298,6 @@ fn test_try_unsupported_pseudo_class() {
 
     assert!(sel.is_none());
 }
-
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -134,3 +134,23 @@ fn test_append_html_multiple() {
 
    assert_eq!(doc.select(r#" #main > div > p > a[href="https://example.com"]:has-text("example.com")"#).length(), 2)
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_append_html_multiple_elements_to_multiple() {
+    let doc: Document = r#"<!DOCTYPE html>
+    <html>
+        <head></head>
+        <body>
+            <div id="main">
+                <div></div>
+                <div></div>
+            </div>
+        </body>
+    </html>"#.into();
+    let q = doc.select("#main div");
+    
+    q.append_html(r#"<span>1</span><span>2</span>"#);
+
+   assert_eq!(doc.select(r#"div span"#).length(), 4)
+}

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -1,6 +1,6 @@
 mod data;
 
-use data::doc_with_siblings;
+use data::{doc_with_siblings, EMPTY_BLOCKS_CONTENTS};
 use dom_query::Document;
 
 #[cfg(target_arch = "wasm32")]
@@ -114,43 +114,41 @@ fn remove_descendant_attributes() {
     assert!(main_sel.has_attr("style"));
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_append_html_multiple() {
-    let doc: Document = r#"<!DOCTYPE html>
-    <html lang="en">
-        <head></head>
-        <body>
-            <div id="main">
-                <div></div>
-                <div></div>
-            </div>
-        </body>
-    </html>"#.into();
+    let doc: Document = EMPTY_BLOCKS_CONTENTS.into();
     let q = doc.select("#main div");
-    
+
     q.append_html(r#"<p class="text">Follow <a href="https://example.com">example.com</a></p>"#);
 
-   assert_eq!(doc.select(r#" #main > div > p > a[href="https://example.com"]:has-text("example.com")"#).length(), 2)
+    assert_eq!(
+        doc.select(r#" #main > div > p > a[href="https://example.com"]:has-text("example.com")"#)
+            .length(),
+        2
+    )
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_append_html_multiple_elements_to_multiple() {
-    let doc: Document = r#"<!DOCTYPE html>
-    <html>
-        <head></head>
-        <body>
-            <div id="main">
-                <div></div>
-                <div></div>
-            </div>
-        </body>
-    </html>"#.into();
+    let doc: Document = EMPTY_BLOCKS_CONTENTS.into();
     let q = doc.select("#main div");
-    
+
     q.append_html(r#"<span>1</span><span>2</span>"#);
 
-   assert_eq!(doc.select(r#"div span"#).length(), 4)
+    assert_eq!(doc.select(r#"div span"#).length(), 4)
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_set_html_multiple_elements_to_multiple() {
+    let doc: Document = EMPTY_BLOCKS_CONTENTS.into();
+    let sel = doc.select("#main div");
+
+    sel.replace_with_html(r#"<p>1</p><p>2</p>"#);
+
+    assert_eq!(doc.select(r#"#main > p:has-text("1")"#).length(), 2);
+    assert_eq!(doc.select(r#"#main > p:has-text("2")"#).length(), 2);
+    assert_eq!(doc.select(r#"#main > p"#).length(), 4)
 }

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -31,7 +31,6 @@ fn test_set_html() {
     let doc = doc_with_siblings();
     let q = doc.select("#main, #foot");
     q.set_html(r#"<div id="replace">test</div>"#);
-
     assert_eq!(doc.select("#replace").length(), 2);
     assert_eq!(doc.select("#main, #foot").length(), 2);
 
@@ -113,4 +112,25 @@ fn remove_descendant_attributes() {
     assert!(!style_in_sel);
 
     assert!(main_sel.has_attr("style"));
+}
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_append_html_multiple() {
+    let doc: Document = r#"<!DOCTYPE html>
+    <html lang="en">
+        <head></head>
+        <body>
+            <div id="main">
+                <div></div>
+                <div></div>
+            </div>
+        </body>
+    </html>"#.into();
+    let q = doc.select("#main div");
+    
+    q.append_html(r#"<p class="text">Follow <a href="https://example.com">example.com</a></p>"#);
+
+   assert_eq!(doc.select(r#" #main > div > p > a[href="https://example.com"]:has-text("example.com")"#).length(), 2)
 }


### PR DESCRIPTION
- Internal logic of `Tree::append_children_from_another_tree` is replaced with `Tree::merge` and `Tree::append_child_of`.
- Internal logic of `Tree::append_prev_siblings_from_another_tree` is replaced with `Tree::merge` and `Tree::append_prev_sibling_of`.