### PR TITLE
Added `NodeRef::prepend_html` and `Selection::prepend_html`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Added `NodeRef::prepend_child` method, that inserts a child at the beginning of node content.
+- Added `NodeRef::prepend_children` method, that inserts a child and it's siblings at the beginning of the node content.
+- Added `NodeRef::prepend_html` method, that parses html string and inserts its parsed nodes at the beginning of the node content.
+- Added `Selection::prepend_html` method, which parses an HTML string and inserts its parsed nodes at the beginning of the content of all matched nodes.
+
 ## [0.8.0] - 2024-11-03
 
 ### Changed

--- a/Examples.md
+++ b/Examples.md
@@ -476,7 +476,6 @@ let html_contents = r#"<!DOCTYPE html>
         <head><title>Test</title></head>
         <body>
             <div class="content">
-                <p>9,8,7</p>
             </div>
             <div class="remove-it">
                 Remove me
@@ -510,6 +509,17 @@ assert_eq!(replace_selection.text().trim(), "Replace me");
 
 //but the document will change
 assert_eq!(doc.select(".replaced").text(),"Replaced".into());
+
+//instead of appending content, you can prepend it
+let mut content_selection = doc.select_single("body .content");
+// you can prepend one element or,
+content_selection.prepend_html(r#"<p class="third">3</p>"#);
+// more:
+content_selection.prepend_html(r#"<p class="first">2</p><p class="second">2</p>"#);
+
+// now the added paragraphs standing in front of `div`
+assert!(doc.select(r#".content > .first + .second + .third + div:has-text("1,2,3")"#).exists());
+
 ```
 </details>
 
@@ -526,7 +536,7 @@ let doc: Document = r#"<!DOCTYPE html>
 <body>
     <div id="main">
         <p id="first">It's</p>
-    <div>
+    </div>
 </body>
 </html>"#.into();
 
@@ -550,7 +560,11 @@ assert!(doc.select(r#"#main #second:has-text("test")"#).exists());
 
 main_node.append_html(r#"<p id="third">Wonderful</p>"#);
 assert_eq!(doc.select("#main #third").text().as_ref(), "Wonderful");
-assert!(doc.select("#first").exists());
+dbg!(doc.html());
+// There is also a `prepend_child` and `prepend_html` methods which allows
+// to insert content to the begging of the node.
+main_node.prepend_html(r#"<p id="minus-one">-1</p><p id="zero">0</p>"#);
+assert!(doc.select("#main > #minus-one + #zero + #first + #second + #third").exists());
 
 // if we need to replace existing element content inside a node with a new one, then use `node.set_html`.
 // It changes the inner html contents of the node.
@@ -565,6 +579,7 @@ assert!(!doc.select("#first").exists());
 main_node.replace_with_html(r#"<span>Tweedledum</span> and <span>Tweedledee</span>"#);
 assert!(!doc.select("#main").exists());
 assert_eq!(doc.select("span + span").text().as_ref(), "Tweedledee");
+
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -509,7 +509,6 @@ let html_contents = r#"<!DOCTYPE html>
         <head><title>Test</title></head>
         <body>
             <div class="content">
-                <p>9,8,7</p>
             </div>
             <div class="remove-it">
                 Remove me
@@ -543,6 +542,16 @@ assert_eq!(replace_selection.text().trim(), "Replace me");
 
 //but the document will change
 assert_eq!(doc.select(".replaced").text(),"Replaced".into());
+
+//instead of appending content, you can prepend it
+let mut content_selection = doc.select_single("body .content");
+// you can prepend one element or,
+content_selection.prepend_html(r#"<p class="third">3</p>"#);
+// more:
+content_selection.prepend_html(r#"<p class="first">2</p><p class="second">2</p>"#);
+
+// now the added paragraphs standing in front of `div`
+assert!(doc.select(r#".content > .first + .second + .third + div:has-text("1,2,3")"#).exists());
 ```
 </details>
 
@@ -559,7 +568,7 @@ let doc: Document = r#"<!DOCTYPE html>
 <body>
     <div id="main">
         <p id="first">It's</p>
-    <div>
+    </div>
 </body>
 </html>"#.into();
 
@@ -583,7 +592,11 @@ assert!(doc.select(r#"#main #second:has-text("test")"#).exists());
 
 main_node.append_html(r#"<p id="third">Wonderful</p>"#);
 assert_eq!(doc.select("#main #third").text().as_ref(), "Wonderful");
-assert!(doc.select("#first").exists());
+dbg!(doc.html());
+// There is also a `prepend_child` and `prepend_html` methods which allows
+// to insert content to the begging of the node.
+main_node.prepend_html(r#"<p id="minus-one">-1</p><p id="zero">0</p>"#);
+assert!(doc.select("#main > #minus-one + #zero + #first + #second + #third").exists());
 
 // if we need to replace existing element content inside a node with a new one, then use `node.set_html`.
 // It changes the inner html contents of the node.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -356,6 +356,20 @@ impl<'a> Selection<'a> {
         }
     }
 
+    /// Parses the html and prepends it to the set of matched elements.
+    pub fn prepend_html<T>(&self, html: T)
+    where
+        T: Into<StrTendril>,
+    {
+        let fragment = Document::fragment(html);
+
+        for node in self.nodes().iter() {
+            let new_node_id = node.tree.get_new_id();
+            node.tree.merge(fragment.tree.clone());
+            node.prepend_children(&new_node_id);
+        }
+    }
+
     /// Appends the elements in the selection to the end of each element
     /// in the set of matched elements.
     pub fn append_selection(&self, sel: &Selection) {

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -153,7 +153,7 @@ fn test_node_replace_with_html() {
     let origin_node = origin_sel.nodes().first().unwrap();
     // replacing origin_node with `p` node, detaching `origin_node` from the tree, origin node is detached
     origin_node.replace_with_html(r#"<p id="replaced"><span id="inline">Something</span></p>"#);
-    println!("{}",doc.html());
+    println!("{}", doc.html());
     // checking if #replaced can be access as next sibling of #before-origin
     assert!(doc.select("#before-origin + #replaced > #inline").exists());
     // checking if #after-origin can be access after it's new previous sibling
@@ -231,4 +231,45 @@ fn test_node_set_text() {
     content_node.set_text(text);
     assert_eq!(content_node.inner_html(), text.into());
     assert_eq!(doc.select("#content").inner_html(), text.into());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_prepend() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+
+    let origin_sel = doc.select_single("#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    // create a new `span` element with id:
+    let span = doc.tree.new_element("span");
+    span.set_attr("id", "first");
+
+    //taking node's place
+    // taking origin_node's place
+    origin_node.prepend_child(&span);
+
+    // #origin is not in the tree now
+    assert!(doc.select("#origin").exists());
+    // #inline is a child of #outline now
+    assert!(doc.select("#origin > #first  + #inline").exists());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_prepend_html() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+
+    let origin_sel = doc.select_single("#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    // you may prepend html fragment with one element inside,
+    origin_node.prepend_html(r#"<span id="third">3</span>"#);
+
+    // or more...
+    origin_node.prepend_html(r#"<span id="first">1</span><span id="second">2</span>"#);
+    dbg!(doc.html());
+    assert!(doc
+        .select("#origin > #first + #second + #third + #inline")
+        .exists());
 }

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -152,3 +152,17 @@ fn test_set_html_multiple_elements_to_multiple() {
     assert_eq!(doc.select(r#"#main > p:has-text("2")"#).length(), 2);
     assert_eq!(doc.select(r#"#main > p"#).length(), 4)
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_prepend_html_multiple_elements_to_multiple() {
+    let doc: Document = EMPTY_BLOCKS_CONTENTS.into();
+    let sel = doc.select("#main div");
+
+    // you may prepend html fragment with one element inside,
+    sel.prepend_html(r#"<span class="third">3</span>"#);
+    // or more
+    sel.prepend_html(r#"<span class="first">1</span><span class="second">2</span>"#);
+
+    assert_eq!(doc.select(r#"div > .first + .second + .third"#).length(), 2)
+}


### PR DESCRIPTION
- Added `NodeRef::prepend_child` method, that inserts a child at the beginning of node content.
- Added `NodeRef::prepend_children` method, that inserts a child and its siblings at the beginning of the node content.
- Added `NodeRef::prepend_html` method, that parses html string and inserts its parsed nodes at the beginning of the node content.
- Added `Selection::prepend_html` method, which parses an HTML string and inserts its parsed nodes at the beginning of the content of all matched nodes.