### PR TITLE
ChildNodes iterator can iterate in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Changing
+
 - Using `Tree::merge_with_fn` instead of `Tree::merge` to reduce code duplication.
+- `Tree::child_ids_of_it` now require `rev` argument. Set `true` to iterate children in reverse order.
+- `NodeRef::children_it` now require `rev` argument. Set `true` to iterate children in reverse order.
 
 ### Added
 - Added `NodeRef::prepend_child` method, that inserts a child at the beginning of node content.
-- Added `NodeRef::prepend_children` method, that inserts a child and it's siblings at the beginning of the node content.
+- Added `NodeRef::prepend_children` method, that inserts a child and its siblings at the beginning of the node content.
 - Added `NodeRef::prepend_html` method, that parses html string and inserts its parsed nodes at the beginning of the node content.
 - Added `Selection::prepend_html` method, which parses an HTML string and inserts its parsed nodes at the beginning of the content of all matched nodes.
 

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -166,7 +166,7 @@ impl Tree {
     ///
     /// `Vec<NodeRef<T>>` A vector of children nodes.
     pub fn children_of(&self, id: &NodeId) -> Vec<NodeRef> {
-        child_nodes(self.nodes.borrow(), id)
+        child_nodes(self.nodes.borrow(), id, false)
             .map(move |id| NodeRef::new(id, self))
             .collect()
     }
@@ -176,8 +176,9 @@ impl Tree {
     /// # Arguments
     ///
     /// * `id` - The id of the node.
-    pub fn child_ids_of_it(&self, id: &NodeId) -> ChildNodes<'_> {
-        child_nodes(self.nodes.borrow(), id)
+    /// * `rev` - If `true`, returns the children in reverse order.
+    pub fn child_ids_of_it(&self, id: &NodeId, rev: bool) -> ChildNodes<'_> {
+        child_nodes(self.nodes.borrow(), id, rev)
     }
 
     /// Returns a vector of the child node ids of a node by id
@@ -186,7 +187,7 @@ impl Tree {
     ///
     /// * `id` - The id of the node.
     pub fn child_ids_of(&self, id: &NodeId) -> Vec<NodeId> {
-        child_nodes(self.nodes.borrow(), id).collect()
+        child_nodes(self.nodes.borrow(), id, false).collect()
     }
 
     /// Gets the first child node of a node by id
@@ -402,7 +403,7 @@ impl Tree {
 
     /// Append a sibling node in the tree before the given node.
     pub fn append_prev_sibling_of(&self, id: &NodeId, new_sibling_id: &NodeId) {
-
+        self.remove_from_parent(new_sibling_id);
         let mut nodes = self.nodes.borrow_mut();
         let node = match nodes.get_mut(id.value) {
             Some(node) => node,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -105,13 +105,13 @@ impl<'a, 'b> Iterator for Matches<'a, NodeRef<'b>> {
                         self.nodes.push(root);
                     }
                     MatchScope::ChildrenOnly => {
-                        self.nodes.extend(root.children().into_iter().rev());
+                        self.nodes.extend(root.children_it(true));
                     }
                 }
             }
 
             while let Some(node) = self.nodes.pop() {
-                self.nodes.extend(node.children().into_iter().rev());
+                self.nodes.extend(node.children_it(true));
 
                 if self.set.contains(&node.id) {
                     continue;

--- a/src/node/serializing.rs
+++ b/src/node/serializing.rs
@@ -36,9 +36,7 @@ impl<'a> Serialize for SerializableNodeRef<'a> {
                 // For children only, add all child nodes
                 self.0
                     .tree
-                    .child_ids_of(&id)
-                    .into_iter()
-                    .rev()
+                    .child_ids_of_it(&id, true)
                     .map(SerializeOp::Open)
                     .collect()
             }
@@ -62,9 +60,7 @@ impl<'a> Serialize for SerializableNodeRef<'a> {
                             ops.extend(
                                 self.0
                                     .tree
-                                    .child_ids_of(&id)
-                                    .into_iter()
-                                    .rev()
+                                    .child_ids_of_it(&id, true)
                                     .map(SerializeOp::Open),
                             );
 
@@ -82,9 +78,7 @@ impl<'a> Serialize for SerializableNodeRef<'a> {
                             ops.extend(
                                 self.0
                                     .tree
-                                    .child_ids_of(&id)
-                                    .into_iter()
-                                    .rev()
+                                    .child_ids_of_it(&id, true)
                                     .map(SerializeOp::Open),
                             );
                             continue;

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -500,7 +500,7 @@ impl<'a> Selection<'a> {
         let mut set = Vec::with_capacity(self.length());
 
         for node in self.nodes() {
-            for child in node.children_it() {
+            for child in node.children_it(false) {
                 if !set.contains(&child.id) && child.is_element() {
                     set.push(child.id);
                     result.push(child);


### PR DESCRIPTION
- `Tree::child_ids_of_it` now require `rev` argument. Set `true` to iterate children in reverse order.
- `NodeRef::children_it` now require `rev` argument. Set `true` to iterate children in reverse order.