### PR TITLE
Fix/node append child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Fixed
 - Fixed `Selection::append_selection` to work with selections with multiple nodes and selections from another tree.
 - Fixed `Selection::replace_with_selection` to work with selections with multiple nodes and selections from another tree.
-
+- Fixed `Node::append_child`, `Node::append_children`, `Node::prepend_child`, and `Node::prepend_children`: these methods now internally remove the child/children from their previous parent node before attachment.
 
 ## [0.8.0] - 2024-11-03
 

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -430,18 +430,14 @@ impl Tree {
             new_sibling.next_sibling = Some(*id);
         };
 
-        if let Some(parent_id) = parent_id {
-            if let Some(parent) = nodes.get_mut(parent_id.value) {
-                if parent.first_child == Some(*id) {
-                    parent.first_child = Some(*new_sibling_id);
-                }
-            };
+        if let Some(parent) = parent_id.and_then(|id| nodes.get_mut(id.value)) {
+            if parent.first_child == Some(*id) {
+                parent.first_child = Some(*new_sibling_id);
+            }
         }
 
-        if let Some(prev_sibling_id) = prev_sibling_id {
-            if let Some(prev_sibling) = nodes.get_mut(prev_sibling_id.value) {
-                prev_sibling.next_sibling = Some(*new_sibling_id);
-            };
+        if let Some(prev_sibling) = prev_sibling_id.and_then(|id| nodes.get_mut(id.value)) {
+            prev_sibling.next_sibling = Some(*new_sibling_id);
         }
     }
 

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -372,32 +372,30 @@ impl Tree {
         let prev_sibling_id = node.prev_sibling;
         let next_sibling_id = node.next_sibling;
 
+        if parent_id.is_none() && prev_sibling_id.is_none() && next_sibling_id.is_none() {
+            return;
+        }
+
         node.parent = None;
         node.next_sibling = None;
         node.prev_sibling = None;
 
-        if let Some(parent_id) = parent_id {
-            if let Some(parent) = nodes.get_mut(parent_id.value) {
-                if parent.first_child == Some(*id) {
-                    parent.first_child = next_sibling_id;
-                }
+        if let Some(parent) = parent_id.and_then(|id| nodes.get_mut(id.value)) {
+            if parent.first_child == Some(*id) {
+                parent.first_child = next_sibling_id;
+            }
 
-                if parent.last_child == Some(*id) {
-                    parent.last_child = prev_sibling_id;
-                }
+            if parent.last_child == Some(*id) {
+                parent.last_child = prev_sibling_id;
             }
         }
 
-        if let Some(prev_sibling_id) = prev_sibling_id {
-            if let Some(prev_sibling) = nodes.get_mut(prev_sibling_id.value) {
-                prev_sibling.next_sibling = next_sibling_id;
-            }
+        if let Some(prev_sibling) = prev_sibling_id.and_then(|id| nodes.get_mut(id.value)) {
+            prev_sibling.next_sibling = next_sibling_id;
         }
 
-        if let Some(next_sibling_id) = next_sibling_id {
-            if let Some(next_sibling) = nodes.get_mut(next_sibling_id.value) {
-                next_sibling.prev_sibling = prev_sibling_id;
-            };
+        if let Some(next_sibling) = next_sibling_id.and_then(|id| nodes.get_mut(id.value)) {
+            next_sibling.prev_sibling = prev_sibling_id;
         }
     }
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -164,7 +164,9 @@ impl<'a> NodeRef<'a> {
     /// Appends another node by id to the selected node.
     #[inline]
     pub fn append_child<P: NodeIdProver>(&self, id_provider: P) {
-        self.tree.append_child_of(&self.id, id_provider.node_id())
+        let new_child_id = id_provider.node_id();
+        self.tree.remove_from_parent(new_child_id);
+        self.tree.append_child_of(&self.id, new_child_id)
     }
 
     /// Appends another node and it's siblings to the selected node.
@@ -173,15 +175,19 @@ impl<'a> NodeRef<'a> {
         let mut next_node = self.tree.get(id_provider.node_id());
 
         while let Some(ref node) = next_node {
-            self.tree.append_child_of(&self.id, &node.id);
+            let node_id = node.id;
             next_node = node.next_sibling();
+            self.tree.remove_from_parent(&node_id);
+            self.tree.append_child_of(&self.id, &node_id);
         }
     }
 
     /// Prepend another node by id to the selected node.
     #[inline]
     pub fn prepend_child<P: NodeIdProver>(&self, id_provider: P) {
-        self.tree.prepend_child_of(&self.id, id_provider.node_id())
+        let new_child_id = id_provider.node_id();
+        self.tree.remove_from_parent(new_child_id);
+        self.tree.prepend_child_of(&self.id, new_child_id)
     }
 
     /// Prepend another node and it's siblings to the selected node.
@@ -196,6 +202,7 @@ impl<'a> NodeRef<'a> {
         while let Some(ref node) = next_node {
             let node_id = node.id;
             next_node = node.prev_sibling();
+            self.tree.remove_from_parent(&node_id);
             self.tree.prepend_child_of(&self.id, &node_id);
         }
     }

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -61,7 +61,8 @@ pub static REPLACEMENT_CONTENTS: &str = r#"<!DOCTYPE html>
         <body>
             <div id="main">
                 <p id="before-origin"></p>
-                <p id="origin"><span id="inline">Something</span></p><p id="after-origin"></p>
+                <p id="origin"><span id="inline">Something</span></p>
+                <p id="after-origin"><span>About</span></p>
             </div>
         </body>
     </html>"#;

--- a/tests/data.rs
+++ b/tests/data.rs
@@ -62,7 +62,7 @@ pub static REPLACEMENT_CONTENTS: &str = r#"<!DOCTYPE html>
             <div id="main">
                 <p id="before-origin"></p>
                 <p id="origin"><span id="inline">Something</span></p>
-                <p id="after-origin"><span>About</span></p>
+                <p id="after-origin"><span>About</span><span>Me</span></p>
             </div>
         </body>
     </html>"#;

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -50,6 +50,24 @@ fn test_append_existing_element() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_append_existing_children() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+    let origin_sel = doc.select_single("p#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    assert_eq!(doc.select_single("#origin").text(), "Something".into());
+
+    let span_sel = doc.select_single(" #after-origin span");
+    let span_node = span_sel.nodes().first().unwrap();
+
+    // this thing adds a child element and its sibling after existing child nodes.
+    origin_node.append_children(span_node);
+
+    assert_eq!(doc.select_single("#origin").text(), "SomethingAboutMe".into());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_prepend_existing_element() {
     let doc = Document::from(REPLACEMENT_CONTENTS);
     let origin_sel = doc.select_single("p#origin");
@@ -63,6 +81,25 @@ fn test_prepend_existing_element() {
     origin_node.prepend_child(span_node);
 
     assert_eq!(doc.select_single("#origin").text(), "AboutSomething".into());
+}
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_prepend_existing_children() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+    let origin_sel = doc.select_single("p#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    assert_eq!(doc.select_single("#origin").text(), "Something".into());
+
+    let span_sel = doc.select_single(" #after-origin span");
+    let span_node = span_sel.nodes().first().unwrap();
+
+    // this thing adds a child element and its sibling before existing child nodes.
+    origin_node.prepend_children(span_node);
+
+    assert_eq!(doc.select_single("#origin").text(), "AboutMeSomething".into());
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -33,6 +33,33 @@ fn test_create_element() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_append_existing_element() {
+    let contents = r#"<!DOCTYPE html>
+    <html lang="en">
+        <head></head>
+        <body>
+            <div id="main">
+                <p id="first">It's</p>
+                <span>Wonderful</span>
+            <div>
+        </body>
+    </html>"#;
+
+    let doc = Document::from(contents);
+    let p_sel = doc.select_single("p");
+    let p_node = p_sel.nodes().first().unwrap();
+
+    let span_sel = doc.select_single("span");
+    let span_node = span_sel.nodes().first().unwrap();
+
+    p_node.append_child(span_node);
+
+    assert!(doc.select("#main > #first > span").exists());
+    assert!(!doc.select("#main > span").exists());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_append_element_html() {
     let contents = r#"<!DOCTYPE html>
     <html lang="en">

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -34,28 +34,35 @@ fn test_create_element() {
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_append_existing_element() {
-    let contents = r#"<!DOCTYPE html>
-    <html lang="en">
-        <head></head>
-        <body>
-            <div id="main">
-                <p id="first">It's</p>
-                <span>Wonderful</span>
-            <div>
-        </body>
-    </html>"#;
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+    let origin_sel = doc.select_single("p#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
 
-    let doc = Document::from(contents);
-    let p_sel = doc.select_single("p");
-    let p_node = p_sel.nodes().first().unwrap();
+    assert_eq!(doc.select_single("#origin").text(), "Something".into());
 
-    let span_sel = doc.select_single("span");
+    let span_sel = doc.select_single(" #after-origin span");
     let span_node = span_sel.nodes().first().unwrap();
 
-    p_node.append_child(span_node);
+    origin_node.append_child(span_node);
 
-    assert!(doc.select("#main > #first > span").exists());
-    assert!(!doc.select("#main > span").exists());
+    assert_eq!(doc.select_single("#origin").text(), "SomethingAbout".into());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_prepend_existing_element() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+    let origin_sel = doc.select_single("p#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    assert_eq!(doc.select_single("#origin").text(), "Something".into());
+
+    let span_sel = doc.select_single(" #after-origin span");
+    let span_node = span_sel.nodes().first().unwrap();
+
+    origin_node.prepend_child(span_node);
+
+    assert_eq!(doc.select_single("#origin").text(), "AboutSomething".into());
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -185,7 +185,6 @@ fn test_replace_with_another_tree_selection() {
     assert_eq!(doc_dst.select(".ad-content .source").length(), 4)
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_append_tree_selection() {


### PR DESCRIPTION
- Fixed `Node::append_child`, `Node::append_children`, `Node::prepend_child`, and `Node::prepend_children`: these methods now internally remove the child/children from their previous parent node before attachment.

**It was very easy to forget to call `child.remove_from_parent()`.**