### PR TITLE
fix `NodeRef::first_element_child`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Fixed `Selection::append_selection` to work with selections with multiple nodes and selections from another tree.
 - Fixed `Selection::replace_with_selection` to work with selections with multiple nodes and selections from another tree.
 - Fixed `Node::append_child`, `Node::append_children`, `Node::prepend_child`, and `Node::prepend_children`: these methods now internally remove the child/children from their previous parent node before attachment.
-- Fixed `NodeRef::first_element_child`. This is an **important** fix -- previously, due to a mistake, it checked the node itself and not its child nodes.
+- Critical fix for `NodeRef::first_element_child`: Previously, due to a logic error, the method checked the node itself instead of its child nodes. This could have caused:
+  - Incorrect element selection in DOM traversal
+  - Unexpected behavior in code relying on first element child detection
+  - Note: Code that depends on this method's behavior should be reviewed after upgrading
 
 ## [0.8.0] - 2024-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Fixed `Selection::append_selection` to work with selections with multiple nodes and selections from another tree.
 - Fixed `Selection::replace_with_selection` to work with selections with multiple nodes and selections from another tree.
 - Fixed `Node::append_child`, `Node::append_children`, `Node::prepend_child`, and `Node::prepend_children`: these methods now internally remove the child/children from their previous parent node before attachment.
+- Fixed `NodeRef::first_element_child`. This is an **important** fix -- previously, due to a mistake, it checked the node itself and not its child nodes.
 
 ## [0.8.0] - 2024-11-03
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -325,13 +325,14 @@ impl<'a> NodeRef<'a> {
         let mut next_child_id = node.first_child;
 
         while let Some(node_id) = next_child_id {
-            if node.is_element() {
+            let child_node = nodes.get(node_id.value)?;
+            if child_node.is_element() {
                 return Some(NodeRef {
                     id: node_id,
                     tree: self.tree,
                 });
             }
-            next_child_id = node.next_sibling;
+            next_child_id = child_node.next_sibling;
         }
         None
     }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -8,19 +8,48 @@ use wasm_bindgen_test::*;
 
 mod alloc;
 
+
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_first_element_child() {
-    let doc: Document = ANCESTORS_CONTENTS.into();
-
-    let parent_sel = doc.select("#parent");
-    let parent_node = parent_sel.nodes().first().unwrap();
-    // Because any indentation marks between HTML elements are considered as text nodes,
-    // there is a necessity to distinguish the first child node and the first child element node.
-    let first_child = parent_node.first_child().unwrap();
-    // striping indentation
-    assert_eq!(first_child.text().trim(), "");
-
-    let first_element_child = parent_node.first_element_child().unwrap();
-    assert_eq!(first_element_child.text(), "Child".into());
+fn test_first_element_child_edge_cases() {
+    let html = r#"
+        <div id="empty"></div>
+        <div id="text-only">Some text</div>
+        <div id="multiple">
+            <span>First</span>
+            <span>Second</span>
+        </div>
+        <div id="nested">
+            <div>
+                <span>Nested</span>
+            </div>
+        </div>
+    "#;
+    
+    let doc: Document = html.into();
+    
+    // Test empty parent
+    let empty_sel = doc.select("#empty");
+    let empty = empty_sel.nodes().first().unwrap();
+    assert!(empty.first_element_child().is_none());
+    
+    // Test text-only parent
+    let text_only_sel = doc.select("#text-only");
+    let text_only = text_only_sel.nodes().first().unwrap();
+    assert!(text_only.first_element_child().is_none());
+    
+    
+    // Test multiple children
+    let multiple_sel = doc.select("#multiple");
+    let multiple = multiple_sel.nodes().first().unwrap();
+    let first = multiple.first_element_child().unwrap();
+    assert_eq!(first.text(), "First".into());
+    assert!(first.is_element());
+    
+    // Test nested elements
+    let nested_sel = doc.select("#nested");
+    let nested = nested_sel.nodes().first().unwrap();
+    let first_nested = nested.first_element_child().unwrap();
+    assert!(first_nested.is_element());
+    assert_eq!(first_nested.first_element_child().unwrap().text(), "Nested".into());
 }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -1,0 +1,26 @@
+mod data;
+
+use data::ANCESTORS_CONTENTS;
+use dom_query::Document;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
+
+mod alloc;
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_first_element_child() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let parent_sel = doc.select("#parent");
+    let parent_node = parent_sel.nodes().first().unwrap();
+    // Because any indentation marks between HTML elements are considered as text nodes,
+    // there is a necessity to distinguish the first child node and the first child element node.
+    let first_child = parent_node.first_child().unwrap();
+    // striping indentation
+    assert_eq!(first_child.text().trim(), "");
+
+    let first_element_child = parent_node.first_element_child().unwrap();
+    assert_eq!(first_element_child.text(), "Child".into());
+}

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -1,6 +1,5 @@
 mod data;
 
-use data::ANCESTORS_CONTENTS;
 use dom_query::Document;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected logic in `first_element_child` to accurately return the first child that is an element.
- **Tests**
	- Added a new test for verifying the behavior of selecting the first child and first element child in a DOM structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->