### PR TITLE
fixed `Tree::nodes` visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+
+## [0.9.1] - 2024-11-10
+
+### Fixed
+- Hide visibility of `Tree::nodes`, which was accidentally exposed in the previous version.
+
+
 ## [0.9.0] - 2024-11-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dom_query"
-version = "0.9.0"
+version = "0.9.1"
 description = "HTML querying and manipulation with CSS seletors"
 license = "MIT"
 repository = "https://github.com/niklak/dom_query"

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -21,7 +21,7 @@ fn fix_node(n: &mut TreeNode, offset: usize) {
 
 /// An implementation of arena-tree.
 pub struct Tree {
-    pub nodes: RefCell<Vec<TreeNode>>,
+    pub(crate) nodes: RefCell<Vec<TreeNode>>,
 }
 
 impl Debug for Tree {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved visibility issue by restricting access to the `Tree::nodes` field.
	- Improved functionality for several selection methods to ensure compatibility with multiple nodes.

- **Documentation**
	- Updated changelog to reflect changes in version `0.9.1`, including enhancements and fixes from previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->