### PR TITLE
`Tree::append_prev_sibling_of` is deprecated;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ## [Unreleased]
 
+## Changed
+
+- `NodeRef::append_prev_sibling` is deprecated, please use `NodeRef::insert_before` instead.
+- `NodeRef::append_prev_siblings` is deprecated, please use `NodeRef::insert_siblings_before` instead.
+- `Tree::append_prev_sibling_of` is deprecated, please use `Tree::insert_before_of` instead.
+
 ## Added
 - Implemented `Ord` trait for `NodeId`
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -323,14 +323,14 @@ impl TreeSink for Document {
                 }
 
                 let id = self.tree.create_node(NodeData::Text { contents: text });
-                self.tree.append_prev_sibling_of(sibling, &id);
+                self.tree.insert_before_of(sibling, &id);
             }
 
             // The tree builder promises we won't have a text node after
             // the insertion point.
 
             // Any other kind of node.
-            NodeOrText::AppendNode(id) => self.tree.append_prev_sibling_of(sibling, &id),
+            NodeOrText::AppendNode(id) => self.tree.insert_before_of(sibling, &id),
         };
     }
 

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -411,8 +411,14 @@ impl Tree {
         }
     }
 
+    #[deprecated(since="0.9.1", note="please use `insert_before_of` instead")]
     /// Append a sibling node in the tree before the given node.
     pub fn append_prev_sibling_of(&self, id: &NodeId, new_sibling_id: &NodeId) {
+        self.insert_before_of(id, new_sibling_id);
+    }
+
+    /// Append a sibling node in the tree before the given node.
+    pub fn insert_before_of(&self, id: &NodeId, new_sibling_id: &NodeId) {
         self.remove_from_parent(new_sibling_id);
         let mut nodes = self.nodes.borrow_mut();
         let node = match nodes.get_mut(id.value) {

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -156,10 +156,19 @@ impl<'a> NodeRef<'a> {
     /// Appends another node by id to the parent node of the selected node.
     /// Another node takes place of the selected node.
     #[inline]
+    #[deprecated(since="0.9.1", note="please use `insert_before` instead")]
     pub fn append_prev_sibling<P: NodeIdProver>(&self, id_provider: P) {
-        self.tree
-            .append_prev_sibling_of(&self.id, id_provider.node_id())
+        self.insert_before(id_provider);
     }
+    /// Appends another node by id to the parent node of the selected node.
+    /// Another node takes place of the selected node.
+    #[inline]
+    pub fn insert_before<P: NodeIdProver>(&self, id_provider: P) {
+        self.tree
+            .insert_before_of(&self.id, id_provider.node_id())
+    }
+
+
 
     /// Appends another node by id to the selected node.
     #[inline]
@@ -207,22 +216,31 @@ impl<'a> NodeRef<'a> {
         }
     }
 
+
     /// Appends another node and it's siblings to the parent node
     /// of the selected node, shifting itself.
     #[inline]
+    #[deprecated(since="0.9.1", note="please use `insert_siblings_before` instead")]
     pub fn append_prev_siblings<P: NodeIdProver>(&self, id_provider: P) {
+        self.insert_siblings_before(id_provider);
+    }
+
+    /// Appends another node and it's siblings to the parent node
+    /// of the selected node, shifting itself.
+    #[inline]
+    pub fn insert_siblings_before<P: NodeIdProver>(&self, id_provider: P) {
         let mut next_node = self.tree.get(id_provider.node_id());
 
         while let Some(node) = next_node {
             next_node = node.next_sibling();
-            self.tree.append_prev_sibling_of(&self.id, &node.id);
+            self.tree.insert_before_of(&self.id, &node.id);
         }
     }
 
     /// Replaces the current node with other node by id. It'is actually a shortcut of two operations:
     /// [`NodeRef::append_prev_sibling`] and [`NodeRef::remove_from_parent`].
     pub fn replace_with<P: NodeIdProver>(&self, id_provider: P) {
-        self.append_prev_sibling(id_provider.node_id());
+        self.insert_before(id_provider.node_id());
         self.remove_from_parent();
     }
 
@@ -234,7 +252,7 @@ impl<'a> NodeRef<'a> {
     {
         let fragment = Document::fragment(html);
         self.tree.merge_with_fn(fragment.tree, |node_id| {
-            self.append_prev_siblings(&node_id);
+            self.insert_siblings_before(&node_id);
         });
         self.remove_from_parent();
     }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -421,7 +421,7 @@ impl<'a> Selection<'a> {
 
         for node in self.nodes().iter() {
             node.tree.merge_with_fn(fragment.tree.clone(), |node_id| {
-                node.append_prev_siblings(&node_id)
+                node.insert_siblings_before(&node_id)
             });
         }
 
@@ -444,7 +444,7 @@ impl<'a> Selection<'a> {
         let sel_nodes = sel.nodes();
         for node in self.nodes() {
             node.tree.copy_nodes_with_fn(sel_nodes, |new_node_id| {
-                node.append_prev_sibling(&new_node_id)
+                node.insert_before(&new_node_id)
             });
         }
 

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -162,7 +162,7 @@ fn test_change_parent_node() {
     p.set_attr("id", "outline");
 
     // taking origin_node's place
-    origin_node.append_prev_sibling(&p.id);
+    origin_node.insert_before(&p.id);
     // remove it from it's current parent
     origin_node.remove_from_parent();
     // append it to new p element
@@ -249,7 +249,7 @@ fn test_node_replace_with_reparent() {
 
     //taking node's place
     // taking origin_node's place
-    origin_node.append_prev_sibling(&p.id);
+    origin_node.insert_before(&p.id);
     // remove it from it's current parent
     origin_node.remove_from_parent();
     // attach all children nodes to new p element

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -8,6 +8,7 @@ use wasm_bindgen_test::*;
 
 mod alloc;
 
+
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_create_element() {
@@ -170,6 +171,54 @@ fn test_change_parent_node() {
 
     assert!(doc.select("#outline > #origin > #inline").exists());
 }
+
+#[allow(deprecated)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_change_parent_node_old() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+
+    let origin_sel = doc.select_single("#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    // create a new `p` element with id:
+    let p = doc.tree.new_element("p");
+    p.set_attr("id", "outline");
+
+    // taking origin_node's place
+    origin_node.append_prev_sibling(&p.id);
+    // remove it from it's current parent
+    origin_node.remove_from_parent();
+    // append it to new p element
+    p.append_child(&origin_node.id);
+
+    assert!(doc.select("#outline > #origin > #inline").exists());
+}
+
+#[allow(deprecated)]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_change_parent_nodes_old() {
+    let doc = Document::from(REPLACEMENT_CONTENTS);
+
+    let origin_sel = doc.select_single("#origin");
+    let origin_node = origin_sel.nodes().first().unwrap();
+
+    // create a new `p` element with id:
+    let p = doc.tree.new_element("p");
+    p.set_attr("id", "outline");
+
+    // taking origin_node's place
+    origin_node.append_prev_siblings(&p.id);
+    // remove it from it's current parent
+    origin_node.remove_from_parent();
+    // append it to new p element
+    p.append_child(&origin_node.id);
+
+    assert!(doc.select("#outline > #origin > #inline").exists());
+}
+
+
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]


### PR DESCRIPTION
…de/node_ref.rs: `NodeRef::append_prev_siblings` is deprecated; `NodeRef::append_prev_sibling` is deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new methods for node manipulation: `insert_before`, `insert_siblings_before`, and `insert_before_of`.
- **Deprecations**
	- Deprecated methods: `append_prev_sibling`, `append_prev_siblings`, and `append_prev_sibling_of`.
- **Bug Fixes**
	- Improved logic in node manipulation methods to ensure correct sibling relationships and DOM traversal.
- **Tests**
	- Updated tests to replace deprecated methods with new implementations for better clarity and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->