### PR TITLE
add missing tests for `Document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This allows querying into the `noscript` element.
 - Implemented `NodeRef::descendants_it` method, which allows iterating over all descendants of a node.
 - Implemented `NodeRef::descendants` method, which returns a vector of all descendants of a node.
 
+## Fix
+- `Document::text` method now returns the text content, whereas previously it returned an empty string.
+
 ## [0.9.1] - 2024-11-10
 
 ### Fixed

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -559,7 +559,7 @@ impl<'a> NodeRef<'a> {
         while let Some(id) = ops.pop() {
             if let Some(node) = nodes.get(id.value) {
                 match node.data {
-                    NodeData::Element(_) => {
+                    NodeData::Document | NodeData::Fragment | NodeData::Element(_) => {
                         ops.extend(self.tree.child_ids_of_it(&id, true));
                     }
                     NodeData::Text { ref contents } => text.push_tendril(contents),

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -360,7 +360,7 @@ impl<'a> NodeRef<'a> {
         while let Some(node_id) = next_child_id {
             let child_node = nodes.get(node_id.value)?;
             if child_node.is_element() {
-                return Some(NodeRef::new(node_id, self.tree))
+                return Some(NodeRef::new(node_id, self.tree));
             }
             next_child_id = child_node.next_sibling;
         }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -130,7 +130,6 @@ fn test_descendants() {
     assert_eq!(descendants_id_names, expected_id_names);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_last_child() {
@@ -139,17 +138,16 @@ fn test_last_child() {
     let parent_sel = doc.select_single("#parent");
     assert!(parent_sel.exists());
     let last_child = parent_sel.nodes().first().and_then(|n| n.last_child());
-    
+
     // when dealing with formatted documents, the last child may be a text node like "\n   "
     assert!(last_child.unwrap().is_text());
 
     let parent_sel = doc.select_single("#grand-parent-sibling");
     assert!(parent_sel.exists());
-    let last_child = parent_sel.nodes().first().and_then(|n|n.last_child());
-    
+    let last_child = parent_sel.nodes().first().and_then(|n| n.last_child());
+
     assert!(last_child.is_none());
 }
-
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -168,12 +166,38 @@ fn test_is_comment() {
     let doc: Document = ANCESTORS_CONTENTS.into();
     let ancestor_sel = doc.select_single("body");
     let ancestor_node = ancestor_sel.nodes().first().unwrap();
-    let first_comment = ancestor_node.children_it(false).find(|n| n.is_comment()).unwrap();
-    
+    let first_comment = ancestor_node
+        .children_it(false)
+        .find(|n| n.is_comment())
+        .unwrap();
+
     let comment = first_comment.query_or("".to_string(), |n| match n.data {
-        NodeData::Comment{ref contents} => contents.to_string(),
+        NodeData::Comment { ref contents } => contents.to_string(),
         _ => "".to_string(),
     });
 
     assert_eq!(comment, "Ancestors");
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_element_children() {
+    let doc: Document = r#"<!DOCTYPE html>
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <div class="main"><div>1</div><div>2</div><div>3</div>Inline text</div>
+        <body>
+    </html>"#
+        .into();
+    let sel = doc.select_single("div.main");
+
+    // our main node
+    let main_node = sel.nodes().first().unwrap();
+    // `Node::children` includes all children nodes of its, not only element, but also text
+    // tabs and newlines considered as text.
+    assert_eq!(main_node.children().len(), 4);
+
+    // `Node::element_children` includes only elements nodes
+    assert_eq!(main_node.element_children().len(), 3);
 }

--- a/tests/pseudo-classes.rs
+++ b/tests/pseudo-classes.rs
@@ -7,7 +7,7 @@ mod alloc;
 
 const SIMPLE_LIST_CONTENT: &str = r#"<!DOCTYPE html>
     <html>
-        <head>Test</head>
+        <head><title>Test</title></head>
         <body>
            <ul class="list">
                <li>1</li>
@@ -34,7 +34,7 @@ const LINKS_CONTENT: &str = r#"<!DOCTYPE html>
 
 const EMPTY_HEADINGS_CONTENT: &str = r#"<!DOCTYPE html>
     <html>
-        <head>Test</head>
+        <head><title>Test</title></head>
         <body>
            <h1>
            </h1>

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -246,3 +246,29 @@ fn test_replace_with_another_tree_selection_empty() {
     // sel_dst remained without changes
     assert_eq!(doc_dst.select(".ad-content span").length(), 2)
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_rename_selection() {
+    let doc: Document = r#"<!DOCTYPE html>
+    <html>
+        <head><title>Test</title></head>
+        <body>
+            <div class="content">
+                <div>1</div>
+                <div>2</div>
+                <div>3</div>
+            </div>
+        <body>
+    </html>"#
+        .into();
+    let sel = doc.select("div.content > div");
+
+    assert_eq!(sel.length(), 3);
+
+    sel.rename("p");
+
+    assert_eq!(doc.select("div.content > div").length(), 0);
+
+    assert_eq!(doc.select("div.content > p").length(), 3);
+}

--- a/tests/selection-property.rs
+++ b/tests/selection-property.rs
@@ -3,7 +3,7 @@ mod data;
 use data::doc;
 use data::doc_with_siblings;
 
-use data::ATTRS_CONTENTS;
+use data::{ANCESTORS_CONTENTS, ATTRS_CONTENTS};
 use dom_query::Document;
 
 #[cfg(target_arch = "wasm32")]
@@ -221,55 +221,6 @@ fn test_has_attr() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_rename_tags() {
-    let doc: Document = r#"<!DOCTYPE html>
-    <html>
-        <head><title>Test</title></head>
-        <body>
-            <div class="content">
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-            </div>
-        <body>
-    </html>"#
-        .into();
-    let sel = doc.select("div.content > div");
-
-    assert_eq!(sel.length(), 3);
-
-    sel.rename("p");
-
-    assert_eq!(doc.select("div.content > div").length(), 0);
-
-    assert_eq!(doc.select("div.content > p").length(), 3);
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_element_children() {
-    let doc: Document = r#"<!DOCTYPE html>
-    <html>
-        <head><title>Test</title></head>
-        <body>
-            <div class="main"><div>1</div><div>2</div><div>3</div>Inline text</div>
-        <body>
-    </html>"#
-        .into();
-    let sel = doc.select_single("div.main");
-
-    // our main node
-    let main_node = sel.nodes().first().unwrap();
-    // `Node::children` includes all children nodes of its, not only element, but also text
-    // tabs and newlines considered as text.
-    assert_eq!(main_node.children().len(), 4);
-
-    // `Node::element_children` includes only elements nodes
-    assert_eq!(main_node.element_children().len(), 3);
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_immediate_text() {
     let doc: Document = r#"<!DOCTYPE html>
     <html>
@@ -322,4 +273,54 @@ fn test_remove_all_attrs() {
     sel.remove_all_attrs();
 
     assert!(!doc.select(r#"font[face]"#).exists());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_doc_try_html() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let html = doc.try_html();
+    assert!(html.is_some());
+
+    let inner_html = doc.try_inner_html();
+    assert!(inner_html.is_some());
+    // because of whitespace serialization serialized content will be different from the original content.
+    let got_html = html
+        .unwrap()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("");
+    let expected = ANCESTORS_CONTENTS
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("");
+    assert_eq!(got_html, expected);
+
+    // Calling `try_inner_html` and `try_html` on `Document` will produce the same result.
+    // The same thing applies to the `inner_html` and `html` methods.
+    let got_inner_html = inner_html
+        .unwrap()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("");
+    assert_eq!(got_inner_html, expected);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_try_html() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let sel = doc.select("#parent > #third-child");
+    assert_eq!(sel.try_html(), None);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_try_inner_html() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let sel = doc.select("#parent > #third-child");
+    assert_eq!(sel.try_inner_html(), None);
 }

--- a/tests/selection-property.rs
+++ b/tests/selection-property.rs
@@ -277,7 +277,7 @@ fn test_remove_all_attrs() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_doc_try_html() {
+fn test_doc_try_serialize_html() {
     let doc: Document = ANCESTORS_CONTENTS.into();
 
     let html = doc.try_html();
@@ -305,6 +305,40 @@ fn test_doc_try_html() {
         .collect::<Vec<_>>()
         .join("");
     assert_eq!(got_inner_html, expected);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_doc_serialize_html() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let html = doc.html();
+
+    let inner_html = doc.inner_html();
+    // because of whitespace serialization serialized content will be different from the original content.
+    let got_html = html.split_whitespace().collect::<Vec<_>>().join("");
+    let expected = ANCESTORS_CONTENTS
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("");
+    assert_eq!(got_html, expected);
+
+    // Calling `try_inner_html` and `try_html` on `Document` will produce the same result.
+    // The same thing applies to the `inner_html` and `html` methods.
+    let got_inner_html = inner_html.split_whitespace().collect::<Vec<_>>().join("");
+    assert_eq!(got_inner_html, expected);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_doc_text() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    // normalizing text for testing purpose.
+    let text = doc.text().split_whitespace().collect::<Vec<_>>().join(" ");
+    // The result includes html > head > title, just like goquery does.
+    // Therefore, it must contain the text from the title and the texts from the two blocks.
+    assert_eq!(text, "Test Child Child");
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/selection-query.rs
+++ b/tests/selection-query.rs
@@ -2,7 +2,7 @@ mod data;
 
 use data::{doc, ANCESTORS_CONTENTS, HEADING_CONTENTS};
 
-use dom_query::Document;
+use dom_query::{Document, Selection};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 
@@ -133,4 +133,25 @@ fn test_is_empty_selection() {
     assert!(third_child_sel.is_empty());
 
     assert!(!first_child_sel.is_selection(&third_child_sel));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_is_has() {
+    let contents = r#"<!DOCTYPE html>
+    <html>
+        <body>
+            <div><img src="image.png"></div>
+            <div id="anchor"></div>
+        </body>
+    </html>"#;
+    let doc: Document = contents.into();
+    let sel = doc.select("#anchor");
+
+    let anchor_node = sel.nodes().first().unwrap();
+
+    let prev_sibling = anchor_node.prev_element_sibling().unwrap();
+    let prev_sel = Selection::from(prev_sibling.clone());
+
+    assert!(prev_sel.is("*:has( > img:only-child)"));
 }

--- a/tests/selection-query.rs
+++ b/tests/selection-query.rs
@@ -87,7 +87,7 @@ fn test_try_filter_selection() {
 fn test_filter_selection_other() {
     let doc: Document = r#"<!DOCTYPE html>
     <html lang="en">
-        <head>TEST</head>
+        <head><title>Test</title></head>
         <body>
             <div class="content">
                 <p>Content text has a <a href="/0">link</a></p>

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -274,7 +274,7 @@ fn test_doc_uppercase() {
 fn test_select_empty() {
     let contents = r#"<!DOCTYPE html>
     <html>
-        <head>Test</head>
+       <head><title>Test</title></head>
         <body>
            <div></div>
            <div>Some text</div>

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -469,47 +469,6 @@ fn test_select_inside_noscript() {
     );
 }
 
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_doc_try_html() {
-    
-    let doc: Document = ANCESTORS_CONTENTS.into();
-
-    let html = doc.try_html();
-    assert!(html.is_some());
-
-    let inner_html = doc.try_inner_html();
-    assert!(inner_html.is_some());
-    // because of whitespace serialization serialized content will be different from the original content.
-    let got_html = html.unwrap().split_whitespace().collect::<Vec<_>>().join("");
-    let expected = ANCESTORS_CONTENTS.split_whitespace().collect::<Vec<_>>().join("");
-    assert_eq!(got_html, expected);
-
-    // Calling `try_inner_html` and `try_html` on `Document` will produce the same result.
-    // The same thing applies to the `inner_html` and `html` methods.
-    let got_inner_html = inner_html.unwrap().split_whitespace().collect::<Vec<_>>().join("");
-    assert_eq!(got_inner_html, expected);
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_selection_try_html() {
-    let doc: Document = ANCESTORS_CONTENTS.into();
-
-    let sel = doc.select("#parent > #third-child");
-    assert_eq!(sel.try_html(), None);
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_selection_try_inner_html() {
-    let doc: Document = ANCESTORS_CONTENTS.into();
-
-    let sel = doc.select("#parent > #third-child");
-    assert_eq!(sel.try_inner_html(), None);
-}
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_selection_last() {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the `Document::text` method to return actual text content.
  
- **Tests**
  - Updated existing tests for better HTML structure validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->