### PR TITLE
implemented `NodeRef::normalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This allows querying into the `noscript` element.
 - Implemented `NodeRef::insert_after` method, which allows to insert a node after the selected node.
 - Implemented `NodeRef::descendants_it` method, which allows iterating over all descendants of a node.
 - Implemented `NodeRef::descendants` method, which returns a vector of all descendants of a node.
+- Implemented `NodeRef::normalize` method, which merges adjacent text nodes and removes empty text nodes. 
+`Document::normalize` does the same thing, but across all the document.
 
 ## Fix
 - `Document::text` method now returns the text content, whereas previously it returned an empty string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This allows querying into the `noscript` element.
 - Implemented `NodeRef::normalize` method, which merges adjacent text nodes and removes empty text nodes. 
 `Document::normalize` does the same thing, but across all the document.
 
-## Fix
+## Fixed
 - `Document::text` method now returns the text content, whereas previously it returned an empty string.
 
 ## [0.9.1] - 2024-11-10

--- a/src/document.rs
+++ b/src/document.rs
@@ -117,6 +117,15 @@ impl Document {
     }
 }
 
+impl Document {
+    /// Merges adjacent text nodes and removes empty text nodes.
+    ///
+    /// Normalization is necessary to ensure that adjacent text nodes are merged into one text node.
+    pub fn normalize(&self) {
+        self.root().normalize();
+    }
+}
+
 // traversal methods
 impl Document {
     /// Gets the descendants of the root document node in the current, filter by a selector.

--- a/src/document.rs
+++ b/src/document.rs
@@ -115,12 +115,30 @@ impl Document {
     pub fn text(&self) -> StrTendril {
         self.root().text()
     }
-}
 
-impl Document {
     /// Merges adjacent text nodes and removes empty text nodes.
     ///
     /// Normalization is necessary to ensure that adjacent text nodes are merged into one text node.
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// use dom_query::Document;
+    ///
+    /// let doc = Document::from("<div>Hello</div>");
+    /// let sel = doc.select("div");
+    /// let div = sel.nodes().first().unwrap();
+    /// let text1 = doc.tree.new_text(" ");
+    /// let text2 = doc.tree.new_text("World");
+    /// let text3 = doc.tree.new_text("");
+    /// div.append_child(&text1);
+    /// div.append_child(&text2);
+    /// div.append_child(&text3);
+    /// assert_eq!(div.children().len(), 4);
+    /// doc.normalize();
+    /// assert_eq!(div.children().len(), 1);
+    /// assert_eq!(div.text(), "Hello World".into());
+    /// ```
     pub fn normalize(&self) {
         self.root().normalize();
     }

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -430,11 +430,10 @@ fn test_node_insert_after() {
         .exists());
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_remove_descendants() {
-    // The purpose of this test is to ensure that there is no BorrowMutError 
+    // The purpose of this test is to ensure that there is no BorrowMutError
     // during iteration through descendants, if `descendants()` is used
     let doc = Document::from(ANCESTORS_CONTENTS);
 
@@ -454,10 +453,10 @@ fn test_node_remove_descendants() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 #[should_panic]
 fn test_node_remove_descendants_it_panic() {
-    // The purpose of this test is to ensure that there is a BorrowMutError 
+    // The purpose of this test is to ensure that there is a BorrowMutError
     // during iteration through descendants, if `descendants_it()` is used.
 
-    // This can be resolved at any time by borrowing from `RefCell` 
+    // This can be resolved at any time by borrowing from `RefCell`
     // on each iteration, but this will be a little bit slower.
     let doc = Document::from(ANCESTORS_CONTENTS);
 
@@ -471,4 +470,44 @@ fn test_node_remove_descendants_it_panic() {
                 .map(|el| el.set_attr("data-descendant", &i.to_string()))
         });
     }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_normalize() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let first_child_sel = doc.select_single("#first-child");
+    let first_child = first_child_sel.nodes().first().unwrap();
+
+    assert_eq!(first_child.children_it(false).count(), 1);
+
+    let empty_text = doc.tree.new_text("");
+    let add_text = doc.tree.new_text(" and a tail");
+    first_child.append_child(&empty_text);
+    first_child.append_child(&add_text);
+
+    assert_eq!(first_child.children_it(false).count(), 3);
+    doc.normalize();
+
+    assert_eq!(first_child.children_it(false).count(), 1);
+
+    let grand_sel = doc.select_single("#grand-parent-sibling");
+    let grand_node = grand_sel.nodes().first().unwrap();
+    assert_eq!(grand_node.children_it(false).count(), 0);
+
+    let total_empty_text_nodes = 5;
+
+    for _ in 0..total_empty_text_nodes {
+        let empty_text = doc.tree.new_text("");
+        grand_node.append_child(&empty_text);
+    }
+
+    assert_eq!(
+        grand_node.children_it(false).count(),
+        total_empty_text_nodes
+    );
+
+    grand_node.normalize();
+    assert_eq!(grand_node.children_it(false).count(), 0);
 }

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -482,15 +482,19 @@ fn test_node_normalize() {
 
     assert_eq!(first_child.children_it(false).count(), 1);
 
-    let empty_text = doc.tree.new_text("");
-    let add_text = doc.tree.new_text(" and a tail");
-    first_child.append_child(&empty_text);
-    first_child.append_child(&add_text);
+    let text_1 = doc.tree.new_text(" and a");
+    let text_2 = doc.tree.new_text(" ");
+    let text_3 = doc.tree.new_text("tail");
+    first_child.append_child(&text_1);
+    first_child.append_child(&text_2);
+    first_child.append_child(&text_3);
+    assert_eq!(first_child.text(), "Child and a tail".into());
 
-    assert_eq!(first_child.children_it(false).count(), 3);
+    assert_eq!(first_child.children_it(false).count(), 4);
     doc.normalize();
 
     assert_eq!(first_child.children_it(false).count(), 1);
+    assert_eq!(first_child.text(), "Child and a tail".into());
 
     let grand_sel = doc.select_single("#grand-parent-sibling");
     let grand_node = grand_sel.nodes().first().unwrap();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new method for node manipulation --`normalize`.
	- Added normalization functionality to merge adjacent text nodes and remove empty nodes.

- **Tests**
	- Added a new test function, `test_node_normalize`, to verify node normalization functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->