### PR TITLE
implemented `Selection::set_text` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Added
 - Implemented the `atomic` feature which switches `NodeData` from using `StrTendril` to `Tendril<tendril::fmt::UTF8, tendril::Atomic>`. 
 This allows `NodeData` and all ascending structures, including `Document`, to implement the `Send` trait.
+- Implemented `Selection::set_text` method, which sets the content of each node in the selection to specified content.
 
 ### Changed
 - Internal code changes aimed at reducing calls to `RefCell::borrow` and `RefCell::borrow_mut`.

--- a/examples/send_document.rs
+++ b/examples/send_document.rs
@@ -1,11 +1,10 @@
+use std::error::Error;
 use std::sync::mpsc::channel;
 use std::thread;
-use std::error::Error;
 
 use dom_query::Document;
 
 fn main() -> Result<(), Box<dyn Error>> {
-
     let (tx, rx) = channel();
     thread::spawn(move || {
         let html = include_str!("../test-pages/hacker_news.html");

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -339,7 +339,7 @@ impl TreeNodeOps {
             NodeData::Text { ref mut contents } => {
                 *contents = wrap_tendril(text.into());
             }
-            _ => return,
+            _ => (),
         }
     }
 }

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -95,10 +95,7 @@ impl Tree {
     /// Creates a new node with the given data.
     pub fn create_node(&self, data: NodeData) -> NodeId {
         let mut nodes = self.nodes.borrow_mut();
-        let new_child_id = NodeId::new(nodes.len());
-
-        nodes.push(TreeNode::new(new_child_id, data));
-        new_child_id
+        TreeNodeOps::create_node(nodes.deref_mut(), data)
     }
 
     /// Gets node by id

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -322,7 +322,10 @@ impl NodeRef<'_> {
     }
 
     /// Parses given text and sets its contents to the selected node.
+    ///
+    ///
     /// This operation replaces any contents of the selected node with the given text.
+    /// Doesn't escapes the text.
     pub fn set_text<T>(&self, text: T)
     where
         T: Into<StrTendril>,

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -10,8 +10,7 @@ use html5ever::Attribute;
 
 use tendril::StrTendril;
 
-use crate::entities::copy_attrs;
-use crate::entities::{into_tendril, wrap_tendril, StrWrap};
+use crate::entities::{copy_attrs, into_tendril, StrWrap};
 use crate::Document;
 use crate::Tree;
 use crate::TreeNodeOps;
@@ -328,17 +327,8 @@ impl NodeRef<'_> {
     where
         T: Into<StrTendril>,
     {
-        if self.is_element() {
-            let text_node = self.tree.new_text(text);
-            self.remove_children();
-            self.append_child(&text_node);
-        } else if self.is_text() {
-            self.update(|n| {
-                if let NodeData::Text { contents } = &mut n.data {
-                    *contents = wrap_tendril(text.into());
-                }
-            });
-        }
+        let mut nodes = self.tree.nodes.borrow_mut();
+        TreeNodeOps::set_text(nodes.deref_mut(), &self.id, text);
     }
 }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,5 +1,5 @@
 use std::cell::Ref;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::vec::IntoIter;
 
 use html5ever::Attribute;
@@ -495,6 +495,19 @@ impl Selection<'_> {
             node.tree.merge_with_fn(fragment.tree.clone(), |node_id| {
                 node.prepend_children(&node_id)
             });
+        }
+    }
+
+    /// Sets the content of each element in the selection to specified content. Doesn't escapes the text.
+    ///
+    /// If simple text needs to be inserted, this method is preferable to [Selection::set_html],
+    /// because it is more lightweight -- it does not create a fragment tree underneath.
+    pub fn set_text(&self, text: &str) {
+        if let Some(first) = self.nodes().first() {
+            let mut tree_nodes = first.tree.nodes.borrow_mut();
+            for node in self.nodes() {
+                TreeNodeOps::set_text(tree_nodes.deref_mut(), &node.id, text);
+            }
         }
     }
 }

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -1,6 +1,8 @@
 mod data;
 
-use data::{doc_with_siblings, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_SEL_CONTENTS};
+use data::{
+    doc_with_siblings, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS, REPLACEMENT_SEL_CONTENTS,
+};
 use dom_query::Document;
 
 #[cfg(target_arch = "wasm32")]
@@ -271,4 +273,19 @@ fn test_rename_selection() {
     assert_eq!(doc.select("div.content > div").length(), 0);
 
     assert_eq!(doc.select("div.content > p").length(), 3);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_set_text() {
+    let doc: Document = REPLACEMENT_CONTENTS.into();
+    let sel = doc.select("div > p");
+    sel.set_text("New Text");
+    // expecting 3 paragraphs with having new text
+    assert_eq!(doc.select(r#"p:has-text("New Text")"#).length(), 3);
+
+    // nothing is found, so nothing is changed
+    let sel = doc.select("div > p > span");
+    sel.set_text("New Inline Text");
+    assert_eq!(doc.select(r#"p:has-text("New Inline Text")"#).length(), 0);
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `set_text` method in `Selection` for setting text in selected elements.
	- Added `create_node` and `set_text` methods in `TreeNodeOps` for enhanced node manipulation.
	- Enhanced `set_text` method in `NodeRef` for simplified text handling.

- **Tests**
	- Added tests to verify the functionality of the new `set_text` method in selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->