### PR TITLE
added `Selection::prepend_selection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This allows `NodeData` and all ascending structures, including `Document`, to im
 `Selection::before_html` does the same thing for the **every** node inside selection.
 - Implemented `NodeRef::after_html` method, which allows inserting contents of an HTML fragment after the selected node.
 `Selection::after_html` does the same thing for the **every** node inside selection.
+- Implemented `Selection::prepend_selection` method, which prepends nodes from another selection to the nodes in the current selection.
 
 ### Changed
 - Internal code changes aimed at reducing calls to `RefCell::borrow` and `RefCell::borrow_mut`.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -425,6 +425,13 @@ impl Selection<'_> {
         self.merge_selection_with_fn(sel, |node, new_node_id| node.append_children(new_node_id));
     }
 
+    /// Prepends the elements in the selection to the beginning of each element
+    /// in the set of matched elements.
+    pub fn prepend_selection(&self, sel: &Selection) {
+        //! Note: goquery's behavior is taken as the basis.
+        self.merge_selection_with_fn(sel, |node, new_node_id| node.prepend_children(new_node_id));
+    }
+
     fn merge_selection_with_fn<F>(&self, sel: &Selection, f: F)
     where
         F: Fn(&NodeRef, &NodeId),

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -410,23 +410,26 @@ impl Selection<'_> {
         if sel.is_empty() {
             return;
         }
+        
+        self.merge_selection_with_fn(sel, |node, new_node_id| {
+            node.insert_before(new_node_id);
+        });
+        self.remove();
 
-        sel.remove();
-
-        let sel_nodes = sel.nodes();
-        for node in self.nodes() {
-            node.tree
-                .copy_nodes_with_fn(sel_nodes, |new_node_id| node.insert_before(&new_node_id));
-        }
-
-        self.remove()
     }
 
     /// Appends the elements in the selection to the end of each element
     /// in the set of matched elements.
     pub fn append_selection(&self, sel: &Selection) {
         //! Note: goquery's behavior is taken as the basis.
+        self.merge_selection_with_fn(sel, |node, new_node_id| node.append_children(new_node_id));
+    }
 
+    fn merge_selection_with_fn<F>(&self, sel: &Selection, f: F)
+    where
+        F: Fn(&NodeRef, &NodeId),
+    {
+        //! Note: goquery's behavior is taken as the basis.
         if sel.is_empty() {
             return;
         }
@@ -435,7 +438,7 @@ impl Selection<'_> {
         let sel_nodes = sel.nodes();
         for node in self.nodes() {
             node.tree
-                .copy_nodes_with_fn(sel_nodes, |new_node_id| node.append_children(&new_node_id));
+                .copy_nodes_with_fn(sel_nodes, |new_node_id| f(node, &new_node_id));
         }
     }
 

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -311,3 +311,20 @@ fn test_after_html() {
     sel.after_html(r#"<br><br>"#);
     assert_eq!(doc.select(r#"#main > p + br + br"#).length(), 3)
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_prepend_another_tree_selection() {
+    let doc_dst = Document::from(REPLACEMENT_SEL_CONTENTS);
+
+    let contents_src = r#"<span class="adv">ad</span>"#;
+
+    let doc_src = Document::from(contents_src);
+
+    let sel_dst = doc_dst.select(".ad-content p");
+    let sel_src = doc_src.select("span.adv");
+
+    sel_dst.prepend_selection(&sel_src);
+    assert_eq!(doc_dst.select(".ad-content p > span.adv + span").length(), 2);
+}

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -290,7 +290,6 @@ fn test_selection_set_text() {
     assert_eq!(doc.select(r#"p:has-text("New Inline Text")"#).length(), 0);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_before_html() {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for enhanced node manipulation, including `set_text`, `insert_siblings_after`, and `prepend_selection`.

- **Tests**
	- Added a new test for validating the functionality of prepending selections between documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->