### PR TITLE
Added `Tree::base_uri`

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install stable rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: stable
+        toolchain: 1.83.0
         targets: wasm32-unknown-unknown
     - name: Install wasm-bindgen-cli
       uses: taiki-e/install-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 - Implemented `NodeRef::is_match` and `NodeRef::is` methods, which allow checking if a node matches 
 a given matcher (`&Matcher`) or selector (`&str`) without creating a `Selection` object.
-
+- Implemented `Tree::base_uri`, a quick method that returns the base URI of the document based on the `href` attribute of the `<base>` element. `Document::base_uri` and `NodeRef::base_uri` provide the same functionality. Inspired by [Node: baseURI property]( https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI).
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tendril = "0.4.3"
 foldhash = "0.1.4"
 hashbrown = {version = "0.15.2", default-features = false, features = ["allocator-api2", "inline-more", "default-hasher"], optional = true}
 precomputed-hash = "0.1.1"
-once_cell = {version = "1.20.2"}
 
 [dev-dependencies]
 ureq = {version = "2.12.1", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,15 @@ html5ever = "0.29.0"
 selectors = "0.26.0"
 cssparser = "0.34.0"
 tendril = "0.4.3"
-foldhash = "0.1.3"
+foldhash = "0.1.4"
 hashbrown = {version = "0.15.2", default-features = false, features = ["allocator-api2", "inline-more", "default-hasher"], optional = true}
 precomputed-hash = "0.1.1"
+once_cell = {version = "1.20.2"}
 
 [dev-dependencies]
 ureq = {version = "2.12.1", default-features = false}
 wasm-bindgen-test = "0.3"
-mini-alloc = "0.6.0"
+mini-alloc = "0.7.0"
 
 [features]
 hashbrown = ["dep:hashbrown"]

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ assert_eq!(doc.select("div.content > p").length(), 4);
 ## Crate features
 
 - `hashbrown` — optional, standard hashmaps and hashsets will be replaced `hashbrown` hashmaps and hashsets;
-- `atomic` - options, switches `NodeData` from using `StrTendril` to `Tendril<tendril::fmt::UTF8, tendril::Atomic>`. 
+- `atomic` — options, switches `NodeData` from using `StrTendril` to `Tendril<tendril::fmt::UTF8, tendril::Atomic>`. 
 This allows `NodeData` and all ascending structures, including `Document`, to implement the `Send` trait;
 
 ## Possible issues

--- a/src/document.rs
+++ b/src/document.rs
@@ -123,7 +123,6 @@ impl Document {
     /// `<base>` tag in the document's head. If no such tag is found,
     /// the method returns `None`.
     ///
-    /// The result is cached after the first call.
     pub fn base_uri(&self) -> Option<StrTendril> {
         self.tree.base_uri()
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -117,6 +117,17 @@ impl Document {
         self.root().text()
     }
 
+    /// Finds the base URI of the tree by looking for `<base>` tags in document's head.
+    ///
+    /// The base URI is the value of the `href` attribute of the first
+    /// `<base>` tag in the document's head. If no such tag is found,
+    /// the method returns `None`.
+    ///
+    /// The result is cached after the first call.
+    pub fn base_uri(&self) -> Option<StrTendril> {
+        self.tree.base_uri()
+    }
+
     /// Merges adjacent text nodes and removes empty text nodes.
     ///
     /// Normalization is necessary to ensure that adjacent text nodes are merged into one text node.

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -112,6 +112,17 @@ impl TreeNodeOps {
         None
     }
 
+    /// Finds the first child element of a node that satisfies the given predicate.
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes` - The nodes of the tree.
+    /// * `id` - The id of the parent node.
+    /// * `f` - The predicate to apply to each child element.
+    ///
+    /// # Returns
+    ///
+    /// The id of the first element that satisfies the predicate, if any.
     pub fn find_child_element<F>(nodes: Ref<Vec<TreeNode>>, id: NodeId, f: F) -> Option<NodeId>
     where
         F: Fn(&TreeNode) -> bool,
@@ -123,34 +134,44 @@ impl TreeNodeOps {
             .map(|tree_node| tree_node.id)
     }
 
+    /// Finds the first child element of a node that has the given name.
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes` - The nodes of the tree.
+    /// * `id` - The id of the parent node.
+    /// * `name` - The name of the element to search for.
+    ///
+    /// # Returns
+    ///
+    /// The id of the first element that has the given name, if any.
     pub fn find_child_element_by_name(
         nodes: Ref<Vec<TreeNode>>,
         id: NodeId,
         name: &str,
     ) -> Option<NodeId> {
         Self::find_child_element(nodes, id, |tree_node| {
-            if let Some(node_name) = tree_node.as_element().map(|el| el.node_name()) {
-                if node_name.as_ref() == name {
-                    return true;
-                }
-            }
-            false
+            tree_node
+                .as_element()
+                .map_or(false, |el| el.node_name().as_ref() == name)
         })
     }
 
+    /// Finds the first descendant element of a node that has the given names.
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes` - The nodes of the tree.
+    /// * `id` - The id of the starting node.
+    /// * `names` - The names of the elements to search for.
+    ///
+    /// # Returns
+    ///
+    /// The id of the first descendant element that has the given names, if any.
     pub fn find_descendant_element(nodes: Ref<Vec<TreeNode>>, id: NodeId, names: &[&str]) -> Option<NodeId> {
-        if  names.is_empty() {
-            return None;
-        }
-        let mut current_id = id;
-
-        for name in names {
-            let Some(node_id) = Self::find_child_element_by_name(Ref::clone(&nodes), current_id, name) else {
-                return None;
-            };
-            current_id = node_id;
-        }
-        Some(current_id)
+        names.iter().try_fold(id, |current_id, name| {
+            Self::find_child_element_by_name(Ref::clone(&nodes), current_id, name)
+        })
     }
 }
 

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -130,7 +130,7 @@ impl TreeNodeOps {
         child_nodes(Ref::clone(&nodes), &id, false)
             .filter_map(|node_id| nodes.get(node_id.value))
             .filter(|tree_node| tree_node.is_element())
-            .find(|tree_node| f(&tree_node))
+            .find(|tree_node| f(tree_node))
             .map(|tree_node| tree_node.id)
     }
 

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -111,6 +111,47 @@ impl TreeNodeOps {
         }
         None
     }
+
+    pub fn find_child_element<F>(nodes: Ref<Vec<TreeNode>>, id: NodeId, f: F) -> Option<NodeId>
+    where
+        F: Fn(&TreeNode) -> bool,
+    {
+        child_nodes(Ref::clone(&nodes), &id, false)
+            .filter_map(|node_id| nodes.get(node_id.value))
+            .filter(|tree_node| tree_node.is_element())
+            .find(|tree_node| f(&tree_node))
+            .map(|tree_node| tree_node.id)
+    }
+
+    pub fn find_child_element_by_name(
+        nodes: Ref<Vec<TreeNode>>,
+        id: NodeId,
+        name: &str,
+    ) -> Option<NodeId> {
+        Self::find_child_element(nodes, id, |tree_node| {
+            if let Some(node_name) = tree_node.as_element().map(|el| el.node_name()) {
+                if node_name.as_ref() == name {
+                    return true;
+                }
+            }
+            false
+        })
+    }
+
+    pub fn find_descendant_element(nodes: Ref<Vec<TreeNode>>, id: NodeId, names: &[&str]) -> Option<NodeId> {
+        if  names.is_empty() {
+            return None;
+        }
+        let mut current_id = id;
+
+        for name in names {
+            let Some(node_id) = Self::find_child_element_by_name(Ref::clone(&nodes), current_id, name) else {
+                return None;
+            };
+            current_id = node_id;
+        }
+        Some(current_id)
+    }
 }
 
 // manipulation

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -168,7 +168,11 @@ impl TreeNodeOps {
     /// # Returns
     ///
     /// The id of the first descendant element that has the given names, if any.
-    pub fn find_descendant_element(nodes: Ref<Vec<TreeNode>>, id: NodeId, names: &[&str]) -> Option<NodeId> {
+    pub fn find_descendant_element(
+        nodes: Ref<Vec<TreeNode>>,
+        id: NodeId,
+        names: &[&str],
+    ) -> Option<NodeId> {
         names.iter().try_fold(id, |current_id, name| {
             Self::find_child_element_by_name(Ref::clone(&nodes), current_id, name)
         })

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -1,10 +1,12 @@
-use std::cell::{OnceCell, Ref, RefCell};
+use std::cell::{Ref, RefCell};
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
 
 use html5ever::LocalName;
 use html5ever::{namespace_url, ns, QualName};
 use tendril::StrTendril;
+
+use once_cell::sync::OnceCell;
 
 use crate::entities::{wrap_tendril, InnerHashMap};
 use crate::node::{

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -69,21 +69,22 @@ impl Tree {
         .ok()
     }
 
+    /// Finds the base URI of the tree by looking for `<base>` tags in document's head.
+    ///
+    /// The base URI is the value of the `href` attribute of the first
+    /// `<base>` tag in the document's head. If no such tag is found,
+    /// the method returns `None`.
+    ///
+    /// The result is cached after the first call.
     pub fn base_uri(&self) -> Option<StrTendril> {
         self.base_uri_cache
             .get_or_init(|| {
                 let root = self.root();
                 let nodes = self.nodes.borrow();
-                let Some(base_node_id) =
-                    TreeNodeOps::find_descendant_element(Ref::clone(&nodes), root.id, &["html", "head", "base"])
-                else {
-                    return None;
-                };
                 
-                let Some(base_node) = nodes.get(base_node_id.value) else {
-                    return None;
-                };
-                base_node.as_element().and_then(|el| el.attr("href"))
+                TreeNodeOps::find_descendant_element(Ref::clone(&nodes), root.id, &["html", "head", "base"])
+                    .and_then(|base_node_id| nodes.get(base_node_id.value))
+                    .and_then(|base_node| base_node.as_element()?.attr("href"))
             })
             .clone()
     }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -652,4 +652,7 @@ impl NodeRef<'_> {
     pub fn is(&self, sel: &str) -> bool {
         Matcher::new(sel).map_or(false, |matcher| self.is_match(&matcher))
     }
+    pub fn base_uri(&self) -> Option<StrTendril> {
+        self.tree.base_uri()
+    }
 }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -12,9 +12,9 @@ use tendril::StrTendril;
 
 use crate::entities::copy_attrs;
 use crate::Document;
+use crate::Matcher;
 use crate::Tree;
 use crate::TreeNodeOps;
-use crate::Matcher;
 
 use super::child_nodes;
 use super::id_provider::NodeIdProver;

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -652,7 +652,7 @@ impl NodeRef<'_> {
     pub fn is(&self, sel: &str) -> bool {
         Matcher::new(sel).map_or(false, |matcher| self.is_match(&matcher))
     }
-    
+
     /// Returns the base URI of the document.
     ///
     /// This is the value of the `<base>` element in the document's head, or `None` if the document does not have a `<base>` element.

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -652,6 +652,10 @@ impl NodeRef<'_> {
     pub fn is(&self, sel: &str) -> bool {
         Matcher::new(sel).map_or(false, |matcher| self.is_match(&matcher))
     }
+    
+    /// Returns the base URI of the document.
+    ///
+    /// This is the value of the `<base>` element in the document's head, or `None` if the document does not have a `<base>` element.
     pub fn base_uri(&self) -> Option<StrTendril> {
         self.tree.base_uri()
     }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -221,7 +221,6 @@ fn test_node_prev_sibling() {
     assert!(prev_element_sibling_sel.is("#first-child"));
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_is() {
@@ -232,7 +231,6 @@ fn test_node_is() {
     assert!(parent_node.is("div#parent"));
     assert!(parent_node.is(":has(#first-child)"));
 }
-
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -247,11 +245,9 @@ fn test_text_node_is() {
     assert!(!first_child.is("#text"));
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_base_uri() {
-
     let contents: &str = r#"<!DOCTYPE html>
     <html>
         <head>

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -261,8 +261,21 @@ fn test_node_base_uri() {
     </html>"#;
     let doc = Document::from(contents);
 
+    // during first call of .base_uri, the result will be cached with OnceCell
+    let base_uri = doc.base_uri().unwrap();
+    assert_eq!(base_uri.as_ref(), "https://www.example.com/");
+
     let sel = doc.select_single("#main");
     let node = sel.nodes().first().unwrap();
+    // using cached result. Access at any node of the tree.
     let base_uri = node.base_uri().unwrap();
     assert_eq!(base_uri.as_ref(), "https://www.example.com/");
+}
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_base_uri_none() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+    assert!(doc.base_uri().is_none());
 }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -261,17 +261,16 @@ fn test_node_base_uri() {
     </html>"#;
     let doc = Document::from(contents);
 
-    // during first call of .base_uri, the result will be cached with OnceCell
+    // It may be called from document level.
     let base_uri = doc.base_uri().unwrap();
     assert_eq!(base_uri.as_ref(), "https://www.example.com/");
 
     let sel = doc.select_single("#main");
     let node = sel.nodes().first().unwrap();
-    // using cached result. Access at any node of the tree.
+    // Access at any node of the tree.
     let base_uri = node.base_uri().unwrap();
     assert_eq!(base_uri.as_ref(), "https://www.example.com/");
 }
-
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -246,3 +246,27 @@ fn test_text_node_is() {
 
     assert!(!first_child.is("#text"));
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_base_uri() {
+
+    let contents: &str = r#"<!DOCTYPE html>
+    <html>
+        <head>
+            <base href="https://www.example.com/"/>
+            <title>Test</title>
+        </head>
+        <body>
+            <div id="main"></div>
+            </div>
+        </body>
+    </html>"#;
+    let doc = Document::from(contents);
+
+    let sel = doc.select_single("#main");
+    let node = sel.nodes().first().unwrap();
+    let base_uri = node.base_uri().unwrap();
+    assert_eq!(base_uri.as_ref(), "https://www.example.com/");
+}

--- a/tests/selection-property.rs
+++ b/tests/selection-property.rs
@@ -290,16 +290,15 @@ fn test_selection_query() {
 
     let mut font_faces = vec![];
     for node in sel.nodes() {
-        if let Some(face) = node.query(|tree_node| {
-            tree_node.as_element().and_then(|el| el.attr("face"))
-        }).flatten() {
+        if let Some(face) = node
+            .query(|tree_node| tree_node.as_element().and_then(|el| el.attr("face")))
+            .flatten()
+        {
             font_faces.push(face.to_string());
         }
     }
     assert_eq!(font_faces, vec!["Times", "Arial", "Courier"]);
 }
-
-
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]


### PR DESCRIPTION
- Implemented `Tree::base_uri`, a quick method that returns the base URI of the document based on the `href` attribute of the `<base>` element. `Document::base_uri` and `NodeRef::base_uri` provide the same functionality. Inspired by [Node: baseURI property]( https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added `base_uri()` method to retrieve document base URI.
	- Enhanced tree traversal with new methods for finding child and descendant elements.
	- Introduced additional methods for node matching and selection.

- **Documentation**
	- Minor improvements to README formatting.

- **Tests**
	- Added tests for base URI functionality.
	- Removed some existing node identification tests.

- **Dependencies**
	- Updated `foldhash` and `mini-alloc` dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->