### PR TITLE
Feature/matches set

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
+  audit:
 
     runs-on: ubuntu-latest
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,20 +1,18 @@
 #[cfg(feature = "hashbrown")]
 mod hash {
     use hashbrown::{HashMap, HashSet};
-    pub type NodeIdSet = HashSet<crate::NodeId>;
-    pub type HashSetFx<K> = HashSet<K>;
+    pub type InnerHashSet<K> = HashSet<K>;
     pub type InnerHashMap<K, V> = HashMap<K, V>;
 }
 
 #[cfg(not(feature = "hashbrown"))]
 mod hash {
     use foldhash::{HashMap, HashSet};
-    pub type NodeIdSet = HashSet<crate::NodeId>;
-    pub type HashSetFx<K> = HashSet<K>;
+    pub type InnerHashSet<K> = HashSet<K>;
     pub type InnerHashMap<K, V> = HashMap<K, V>;
 }
 
-pub(crate) use hash::{HashSetFx, InnerHashMap, NodeIdSet};
+pub(crate) use hash::{InnerHashSet, InnerHashMap};
 
 #[cfg(feature = "atomic")]
 mod str_wrap {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -7,7 +7,7 @@ use selectors::parser::{self, SelectorList, SelectorParseErrorKind};
 use selectors::{context, matching, visitor, Element};
 
 use crate::css::{CssLocalName, CssString};
-use crate::entities::NodeIdSet;
+use crate::entities::InnerHashSet;
 use crate::node::NodeRef;
 
 /// CSS selector.
@@ -52,7 +52,7 @@ impl Matcher {
 pub struct Matches<'a, 'b> {
     nodes: Vec<NodeRef<'a>>,
     matcher: &'b Matcher,
-    set: NodeIdSet,
+    set: InnerHashSet<usize>,
     caches: SelectorCaches,
 }
 
@@ -106,7 +106,7 @@ impl<'a> Iterator for Matches<'a, '_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(node) = self.nodes.pop() {
-            if self.set.contains(&node.id) {
+            if self.set.contains(&node.id.value) {
                 continue;
             }
             self.nodes
@@ -116,7 +116,7 @@ impl<'a> Iterator for Matches<'a, '_> {
                 .matcher
                 .match_element_with_caches(&node, &mut self.caches)
             {
-                self.set.insert(node.id);
+                self.set.insert(node.id.value);
                 return Some(node);
             }
         }

--- a/src/node/node_data.rs
+++ b/src/node/node_data.rs
@@ -7,7 +7,7 @@ use selectors::attr::CaseSensitivity;
 use tendril::StrTendril;
 
 use super::NodeId;
-use crate::entities::{into_tendril, wrap_attrs, wrap_tendril, Attr, HashSetFx, StrWrap};
+use crate::entities::{into_tendril, wrap_attrs, wrap_tendril, Attr, InnerHashSet, StrWrap};
 
 fn contains_class(classes: &str, target_class: &str) -> bool {
     classes.split_whitespace().any(|c| c == target_class)
@@ -111,7 +111,7 @@ impl Element {
             return;
         }
 
-        let class_set: HashSetFx<&str> = classes
+        let class_set: InnerHashSet<&str> = classes
             .split(' ')
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -156,7 +156,7 @@ impl Element {
             .iter_mut()
             .find(|attr| &attr.name.local == "class")
         {
-            let mut set: HashSetFx<&str> = attr
+            let mut set: InnerHashSet<&str> = attr
                 .value
                 .split(' ')
                 .map(|s| s.trim())
@@ -230,7 +230,7 @@ impl Element {
             .attrs
             .iter()
             .map(|e| e.name.clone())
-            .collect::<HashSetFx<_>>();
+            .collect::<InnerHashSet<_>>();
 
         self.attrs.extend(
             attrs

--- a/src/node/selector.rs
+++ b/src/node/selector.rs
@@ -163,7 +163,7 @@ impl selectors::Element for NodeRef<'_> {
 
     /// Whether this element is a `link`.
     fn is_link(&self) -> bool {
-        // TODO: This function introduces significant overhead.
+        // TODO: This function adds some overhead.
         // Its purpose in dom_query is unclear.
         // Returning `false` works just fine.
         self.query_or(false, |node| {


### PR DESCRIPTION
- Switch from using `NodeIdSet` to `InnerHashSet<usize>`, since using `usize` is somehow a little bit more efficient than `NodeId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Updated GitHub Actions workflow to focus on code auditing
  - Refined internal type management for hash sets and node identifiers

- **Documentation**
  - Updated inline comment for link detection method to better describe performance characteristics

- **Refactor**
  - Replaced `HashSetFx` and `NodeIdSet` type aliases with `InnerHashSet`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->