### PR TITLE
src/node/node_ref.rs: implement `NodeRef::normalized_char_count`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+
+## [Unreleased]
+
+### Added
+- Implemented `NodeRef::normalized_char_count` which estimates the number of characters in the text of descendant nodes as if the total string were normalized.
+
+
 ## [0.12.0] - 2025-01-16
 
 ### Added

--- a/src/dom_tree.rs
+++ b/src/dom_tree.rs
@@ -1,3 +1,4 @@
+mod helpers;
 mod ops;
 mod traversal;
 mod tree;

--- a/src/dom_tree/helpers.rs
+++ b/src/dom_tree/helpers.rs
@@ -1,0 +1,18 @@
+pub(crate) fn normalized_char_count(text: &str) -> usize {
+    let mut char_count = 0;
+    let mut prev_was_whitespace = true;
+
+    for c in text.chars() {
+        if prev_was_whitespace && c.is_whitespace() {
+            continue;
+        }
+        char_count += 1;
+        prev_was_whitespace = c.is_whitespace();
+    }
+
+    if prev_was_whitespace && char_count > 0 {
+        char_count -= 1;
+    }
+
+    char_count
+}

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -677,4 +677,21 @@ impl NodeRef<'_> {
             .map(|node_id| NodeRef::new(*node_id, self.tree))
             .collect()
     }
+
+    /// Traverses the tree and counts all text content of a node and its descendants,
+    /// but only counting each sequence of whitespace as a single character.
+    ///
+    /// This function will traverse the tree and count all text content
+    /// from the node and its descendants.
+    ///
+    /// It has an advantage over `node.text().split_whitespace().count()`
+    /// because it doesn't need to collect and consume the text content.
+    ///
+    /// # Returns
+    /// The number of characters that would be in the text content if it were normalized,
+    /// where normalization means treating any sequence of whitespace characters as a single space.
+    pub fn normalized_char_count(&self) -> usize {
+        let nodes = self.tree.nodes.borrow();
+        TreeNodeOps::normalized_char_count(nodes, self.id)
+    }
 }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -300,3 +300,31 @@ fn test_node_find() {
     let len_sel_ne = doc.select("body td p").length();
     assert_eq!(len_sel_ne, 0)
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_normalized_char_count() {
+    let contents: &str = r#"
+        <div id="main">
+        A           very 
+                                messy content
+            <span>. A something       that</span>
+            <p>
+            asks to be     normalized     </p>
+
+
+        </div>
+    "#;
+
+    let doc = Document::from(contents);
+    let main_sel = doc.select_single("#main");
+    let main_node = main_sel.nodes().first().unwrap();
+    let expected = main_node
+        .text()
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+        .len();
+    let got = main_node.normalized_char_count();
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
- Implemented `NodeRef::normalized_char_count` which estimates the number of characters in the text of descendant nodes as if the total string were normalized.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a normalized character counting capability to improve text processing accuracy by treating consecutive whitespace as a single character.
- **Documentation**
	- Updated release records to reflect the enhancements in text handling.
- **Tests**
	- Added test cases to ensure that the normalized character count behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->