### PR TITLE
src/dom_tree/traversal.rs: fix `Traversal::find_descendant_elements`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Fixed `NodeRef::find` to correctly collect nodes when there is only one item in the path slice.
+
 ## [0.13.1] - 2025-02-02
 
 ### Fixed

--- a/src/dom_tree/traversal.rs
+++ b/src/dom_tree/traversal.rs
@@ -115,7 +115,9 @@ impl Traversal {
 
                     if node_name.as_ref() == *name {
                         candidates.push(node_id);
-                        continue;
+                        if !is_last {
+                            continue;
+                        }
                     }
                     ops.extend(
                         child_nodes(Ref::clone(nodes), &node_id, is_last)

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -295,6 +295,9 @@ fn test_node_find() {
 
     assert_eq!(got_ids, expected_ids);
 
+    let got_ids_a:Vec<dom_query::NodeId> = root.find(&["a"]).iter().map(|n| n.id).collect();
+    assert_eq!(got_ids_a, expected_ids);
+
     let len_fin_ne = root.find(&["body", "td", "p"]).len();
     assert_eq!(len_fin_ne, 0);
     let len_sel_ne = doc.select("body td p").length();


### PR DESCRIPTION
- Fixed `NodeRef::find` to correctly collect nodes when there is only one item in the path slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved node collection accuracy when processing single-element retrieval paths.
  - Refined the selection flow for descendant elements so only valid candidates are included.
  - Updated the project documentation to reflect these corrections.

- **Tests**
  - Added a test case to verify that anchor elements in the document are correctly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->