### PR TITLE
 Implemented the `NodeRef::id_attr` and `NodeRef::class` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+
+## [Unreleased]
+
+### Added
+- Implemented the `Node::id_attr` and `Node::class` methods, which return the `id` and `class` attributes of the node, respectively. `The Selection::id` and `Selection::class` methods do the same for the **first** node in the selection.
+
+### Changed
+- Use `bit_set::BitSet` instead of `foldhash::HashSet` for the `Matches::next` method. Since it is necessary to ensure there are no duplicates in the `Matches` result, and this check needs to be as cheap as possible, `bit-set` was chosen.
+
+
 ## [0.13.3] - 2025-02-07
 
 ## Fixed

--- a/src/node/node_data.rs
+++ b/src/node/node_data.rs
@@ -84,6 +84,22 @@ impl Element {
         StrTendril::from(self.name.local.as_ref())
     }
 
+    /// Get the class attribute of the node.
+    pub fn class(&self) -> Option<StrTendril> {
+        self.attrs
+            .iter()
+            .find(|a| a.name.local == local_name!("class"))
+            .map(|a| into_tendril(a.value.clone()))
+    }
+
+    /// Get the id attribute of the node.
+    pub fn id(&self) -> Option<StrTendril> {
+        self.attrs
+            .iter()
+            .find(|a| a.name.local == local_name!("id"))
+            .map(|a| into_tendril(a.value.clone()))
+    }
+
     /// Whether the element has the given class.
     pub fn has_class(&self, class: &str) -> bool {
         self.attrs

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -395,6 +395,16 @@ impl NodeRef<'_> {
             .and_then(|node| node.as_element().map(|e| e.node_name()))
     }
 
+    /// Returns the value of the `id` attribute
+    pub fn id_attr(&self) -> Option<StrTendril> {
+        self.query_or(None, |node| node.as_element().and_then(|e| e.id()))
+    }
+
+    /// Returns the value of the `class` attribute
+    pub fn class(&self) -> Option<StrTendril> {
+        self.query_or(None, |node| node.as_element().and_then(|e| e.class()))
+    }
+
     /// Checks if node has a specified class
     pub fn has_class(&self, class: &str) -> bool {
         self.query_or(false, |node| {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -95,6 +95,16 @@ impl Selection<'_> {
         });
     }
 
+    /// Returns the id of the first element in the set of matched elements.
+    pub fn id(&self) -> Option<StrTendril> {
+        self.nodes().first().and_then(|node| node.id_attr())
+    }
+
+    /// Returns the class name of the first element in the set of matched elements.
+    pub fn class(&self) -> Option<StrTendril> {
+        self.nodes().first().and_then(|node| node.class())
+    }
+
     /// Adds the given class to each element in the set of matched elements.
     /// Multiple class names can be specified, separated by a space via multiple arguments.
     pub fn add_class(&self, class: &str) {

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -543,3 +543,28 @@ That's how we keep our code development!
 "#;
     assert_eq!(text.as_ref(), expected);
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_class() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let sel = doc.select("#parent > #first-child");
+    assert_eq!(sel.class().unwrap(), "child".into());
+
+    assert_eq!(doc.select("#parent").class(), None);
+    assert_eq!(doc.select("#non-existing").class(), None);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_id() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let sel = doc.select("#parent > #first-child");
+    assert_eq!(sel.id().unwrap(), "first-child".into());
+
+    assert_eq!(doc.select("body").id(), None);
+    assert_eq!(doc.select("#non-existing").class(), None);
+}

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -566,5 +566,5 @@ fn test_selection_id() {
     assert_eq!(sel.id().unwrap(), "first-child".into());
 
     assert_eq!(doc.select("body").id(), None);
-    assert_eq!(doc.select("#non-existing").class(), None);
+    assert_eq!(doc.select("#non-existing").id(), None);
 }


### PR DESCRIPTION
- Implemented the `Node::id_attr` and `Node::class` methods, which return the `id` and `class` attributes of the node, respectively. `The Selection::id` and `Selection::class` methods do the same for the **first** node in the selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simplified access to element attributes with new methods for retrieving identifiers and class names.

- **Tests**
  - Expanded test coverage to validate correct attribute retrieval and selection behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->