### PR TITLE
src/node/iters.rs: fixed `DescendantNodes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Changed
 - Use `bit_set::BitSet` instead of `foldhash::HashSet` for the `Matches::next` method. Since it is necessary to ensure there are no duplicates in the `Matches` result, and this check needs to be as cheap as possible, `bit-set` was chosen.
 
+### Fixed
+- Fixed an issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants. This affected `NodeRef::descendants` and `NodeRef::descendants_it`. 
 
 ## [0.13.3] - 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Use `bit_set::BitSet` instead of `foldhash::HashSet` for the `Matches::next` method. Since it is necessary to ensure there are no duplicates in the `Matches` result, and this check needs to be as cheap as possible, `bit-set` was chosen.
 
 ### Fixed
-- Fixed an issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants. This affected `NodeRef::descendants` and `NodeRef::descendants_it`. 
+- Issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants. This affected `NodeRef::descendants` and `NodeRef::descendants_it`. 
 
 ## [0.13.3] - 2025-02-07
 

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -145,6 +145,7 @@ pub fn ancestor_nodes<'a>(
 pub struct DescendantNodes<'a> {
     nodes: Ref<'a, Vec<TreeNode>>,
     next_child_id: Option<NodeId>,
+    start_id: NodeId,
 }
 
 impl<'a> DescendantNodes<'a> {
@@ -164,6 +165,7 @@ impl<'a> DescendantNodes<'a> {
         DescendantNodes {
             nodes,
             next_child_id,
+            start_id: *node_id,
         }
     }
 
@@ -175,6 +177,9 @@ impl<'a> DescendantNodes<'a> {
             node.next_sibling
         } else {
             let mut parent = node.parent;
+            if parent == Some(self.start_id) {
+                return None;
+            }
             while let Some(parent_node) = parent.and_then(|id| self.nodes.get(id.value)) {
                 if parent_node.next_sibling.is_some() {
                     return parent_node.next_sibling;

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -136,6 +136,7 @@ fn test_descendants_bound() {
     // previously `DescendantNodes` could traverse beyond the initial node when iterating over descendants.
     let doc: Document = ANCESTORS_CONTENTS.into();
 
+    // multiple descendants, no siblings
     let parent = doc.select("#parent");
     let parent_node = parent.nodes().first().unwrap();
     let descendants_id_names: Vec<String> = parent_node
@@ -145,6 +146,17 @@ fn test_descendants_bound() {
         .collect();
     let expected_id_names = vec!["first-child", "second-child"];
     assert_eq!(descendants_id_names, expected_id_names);
+
+    // one descendant, text
+    let child_sel = doc.select("#first-child");
+    let child_node = child_sel.nodes().first().unwrap();
+    assert_eq!(child_node.descendants_it().count(), 1);
+
+    // no descendants
+    let no_descendants_sel = doc.select("#grand-parent-sibling");
+    let no_descendants_node = no_descendants_sel.nodes().first().unwrap();
+    assert_eq!(no_descendants_node.descendants_it().count(), 0);
+
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -132,6 +132,23 @@ fn test_descendants() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_descendants_bound() {
+    // previously `DescendantNodes` could traverse beyond the initial node when iterating over descendants.
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let parent = doc.select("#parent");
+    let parent_node = parent.nodes().first().unwrap();
+    let descendants_id_names: Vec<String> = parent_node
+        .descendants_it()
+        .filter(|n| n.is_element())
+        .map(|n| n.attr_or("id", "").to_string())
+        .collect();
+    let expected_id_names = vec!["first-child", "second-child"];
+    assert_eq!(descendants_id_names, expected_id_names);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_last_child() {
     let doc: Document = ANCESTORS_CONTENTS.into();
 

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -544,7 +544,6 @@ That's how we keep our code development!
     assert_eq!(text.as_ref(), expected);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_selection_class() {


### PR DESCRIPTION
- Fixed an issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants. This affected `NodeRef::descendants` and `NodeRef::descendants_it`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected descendant traversal to ensure iteration does not exceed the intended element scope.
- **Tests**
  - Introduced tests to verify that descendant traversal remains within its defined boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->