### PR TITLE
src/mini_selector/extension.rs: rename `snap_is` -> `mini_is`, `snap_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Added
 - Implemented the `markdown` feature, which allows serializing a `Document` or `NodeRef` into Markdown text using the `md()` method.
 - Implemented the `mini_selector` feature, providing a lightweight and faster alternative for element matching with limited CSS selector support.
-This includes `NodeRef` additional methods: `find_descendants`, `try_find_descendants`, `snap_is`, and `snap_match`.
+This includes `NodeRef` additional methods: `find_descendants`, `try_find_descendants`, `mini_is`, and `mini_match`.
 
 ## [0.14.0] - 2025-02-16
 

--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ assert_eq!(got.as_ref(), expected);
 This allows `NodeData` and all ascending structures, including `Document`, to implement the `Send` trait;
 - `markdown` — optional, enables the `Document::md` and `NodeRef::md` methods, allowing serialization of a document or node to `Markdown` text. 
 - `mini_selector` — optional, provides a lightweight and faster alternative for element matching with limited CSS selector support.  
-  This includes additional `NodeRef` methods: `find_descendants`, `try_find_descendants`, `snap_is`, and `snap_match`.  
+  This includes additional `NodeRef` methods: `find_descendants`, `try_find_descendants`, `mini_is`, and `mini_match`.  
 
 ## Possible issues
 * [wasm32 compilation](https://niklak.github.io/dom_query_by_example/WASM32-compilation.html)


### PR DESCRIPTION
- renamed `snap_is` -> `mini_is`, `snap_match` to `mini_match`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated user documentation to reflect improvements in the element matching feature.
- **Refactor**
	- Streamlined naming conventions in the element matching functionality to enhance consistency across the product.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->