### PR TITLE
src/selection.rs: fix `Selection::select` order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Implemented the `mini_selector` feature, providing a lightweight and faster alternative for element matching with limited CSS selector support.
 This includes `NodeRef` additional methods: `find_descendants`, `try_find_descendants`, `mini_is`, and `mini_match`.
 
+### Fixed
+-  `Selection::select` now returns nodes in ascending order if there were multiple underlying root nodes. If there was only one root node, it still returns nodes in ascending order, just as before.
+
 ## [0.14.0] - 2025-02-16
 
 ### Added

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -545,7 +545,7 @@ impl<'a> Selection<'a> {
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection<'a> {
         Selection {
             nodes: Matches::from_list(
-                self.nodes.clone().into_iter(),
+                self.nodes.clone().into_iter().rev(),
                 matcher,
                 MatchScope::ChildrenOnly,
             )
@@ -583,7 +583,7 @@ impl<'a> Selection<'a> {
     /// containing elements of the single (first) match..
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection<'a> {
         let node = Matches::from_list(
-            self.nodes.clone().into_iter(),
+            self.nodes.clone().into_iter().rev(),
             matcher,
             MatchScope::ChildrenOnly,
         )

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -567,3 +567,23 @@ fn test_selection_id() {
     assert_eq!(doc.select("body").id(), None);
     assert_eq!(doc.select("#non-existing").id(), None);
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_is_sorted() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let sel_0 = doc.select("div");
+    let nodes_id_0 = sel_0.nodes().iter().map(|n| n.id).collect::<Vec<_>>();
+    assert!(nodes_id_0.is_sorted());
+
+
+    let sel_1 = doc.select("#great-ancestor > div").select("div > div");
+    let nodes_id_1 = sel_1.nodes().iter().map(|n| n.id).collect::<Vec<_>>();
+    assert!(nodes_id_1.is_sorted());
+
+    let sel_2 = doc.select("#great-ancestor div").select("div > div");
+    let nodes_id_2 = sel_2.nodes().iter().map(|n| n.id).collect::<Vec<_>>();
+    println!("{:?}", nodes_id_2);
+    assert!(nodes_id_2.is_sorted());
+}


### PR DESCRIPTION
-  `Selection::select` now returns nodes in ascending order if there were multiple underlying root nodes. If there was only one root node, it still returns nodes in ascending order, just as before.