### PR TITLE
src/serializing/md.rs: improve markdown serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Improved `markdown` serialization for `NodeRef`: 
+  - No longer adds `\n\n\` after elements that require a newline at the end if `\n\n` is already present.
+  - Now avoids encoding strings inside `code` elements, except for the \` character.
 
 ## [0.15.0] - 2025-03-01
 


### PR DESCRIPTION
- Improved `markdown` serialization for `NodeRef`: 
  - No longer adds `\n\n\` after elements that require a newline at the end if `\n\n` is already present.
  - Now avoids encoding strings inside `code` elements, except for the \` character.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to highlight the latest markdown serialization improvements.

- **Bug Fixes**
  - Resolved issues causing extra newline characters and improved the accuracy of code element rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->