### PR TITLE
Fix `DescendantNodes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed 
+- Fixed another issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants, affecting `NodeRef::descendants` and `NodeRef::descendants_it`, e.g., when the tree had been modified.
+
 ## [0.15.1] - 2025-03-02
 
 ### Fixed

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -199,7 +199,6 @@ impl Iterator for DescendantNodes<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         let current_id = self.next_child_id?;
         self.next_child_id = self.get_child_or_sibling(&current_id);
-        
         Some(current_id)
     }
 }

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -198,7 +198,11 @@ impl Iterator for DescendantNodes<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current_id = self.next_child_id?;
+        if current_id <= self.start_id {
+            return None;
+        }
         self.next_child_id = self.get_child_or_sibling(&current_id);
+        
         Some(current_id)
     }
 }

--- a/src/node/iters.rs
+++ b/src/node/iters.rs
@@ -177,10 +177,10 @@ impl<'a> DescendantNodes<'a> {
             node.next_sibling
         } else {
             let mut parent = node.parent;
-            if parent == Some(self.start_id) {
-                return None;
-            }
             while let Some(parent_node) = parent.and_then(|id| self.nodes.get(id.value)) {
+                if parent == Some(self.start_id) {
+                    return None;
+                }
                 if parent_node.next_sibling.is_some() {
                     return parent_node.next_sibling;
                 } else {
@@ -198,9 +198,6 @@ impl Iterator for DescendantNodes<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current_id = self.next_child_id?;
-        if current_id <= self.start_id {
-            return None;
-        }
         self.next_child_id = self.get_child_or_sibling(&current_id);
         
         Some(current_id)

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -158,6 +158,31 @@ fn test_descendants_bound() {
     assert_eq!(no_descendants_node.descendants_it().count(), 0);
 }
 
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_descendants_after_mod() {
+    // previously `DescendantNodes` could traverse beyond the initial node when iterating over descendants.
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let parent = doc.select_single("#parent");
+    let parent_node = parent.nodes().first().unwrap();
+
+    let grand_parent = doc.select_single("#grand-parent");
+    let grand_parent_node = grand_parent.nodes().first().unwrap();
+
+    grand_parent_node.replace_with(parent_node);
+    parent_node.append_child(grand_parent_node);
+
+    let descendants_id_names: Vec<String> = parent_node
+        .descendants_it()
+        .filter(|n| n.is_element())
+        .map(|n| n.attr_or("id", "").to_string())
+        .collect();
+    let expected_id_names = vec!["first-child", "second-child", "grand-parent"];
+    assert_eq!(descendants_id_names, expected_id_names);
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_last_child() {


### PR DESCRIPTION
- Fixed another issue where `DescendantNodes` could traverse beyond the initial node when iterating over descendants, affecting `NodeRef::descendants` and `NodeRef::descendants_it`, e.g., when the tree had been modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the descendant node traversal logic to prevent iterating beyond the specified starting node.
- **Tests**
  - Added a new test to ensure correct behavior of descendant traversal after modifications to the document structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->