### PR TITLE
Feature/descendant matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Revised internal code related to element matching. Now, if there is only one root node, `DescendantMatches` (based on `DescendantNodes`) will be used as the internal iterator, which provides a faster approach and doesn't require an additional check for result duplicates. In the other case, `Matches` will be used, which, as previously, performs a check for duplicates.
+
 ## [0.15.2] - 2025-03-06
 
 ### Fixed 

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::entities::wrap_tendril;
-use crate::matcher::{MatchScope, Matcher, NodeMatches};
+use crate::matcher::{MatchScope, Matcher, DescendantMatches};
 use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
@@ -206,7 +206,7 @@ impl Document {
     /// It returns a new selection object containing these matched elements.
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection {
         let root = self.tree.root();
-        let nodes = NodeMatches::new(root, matcher, MatchScope::IncludeNode).collect();
+        let nodes = DescendantMatches::new(root, matcher, MatchScope::IncludeNode).collect();
 
         Selection { nodes }
     }
@@ -214,7 +214,7 @@ impl Document {
     /// Gets the descendants of the root document node in the current, filter by a matcher.
     /// It returns a new selection object containing elements of the single (first) match.    
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection {
-        let node = NodeMatches::new(self.tree.root(), matcher, MatchScope::IncludeNode).next();
+        let node = DescendantMatches::new(self.tree.root(), matcher, MatchScope::IncludeNode).next();
 
         match node {
             Some(node) => Selection { nodes: vec![node] },

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::entities::wrap_tendril;
-use crate::matcher::{MatchScope, Matcher, DescendantMatches};
+use crate::matcher::{Matcher, DescendantMatches};
 use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
@@ -206,7 +206,7 @@ impl Document {
     /// It returns a new selection object containing these matched elements.
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection {
         let root = self.tree.root();
-        let nodes = DescendantMatches::new(root, matcher, MatchScope::IncludeNode).collect();
+        let nodes = DescendantMatches::new(root, matcher).collect();
 
         Selection { nodes }
     }
@@ -214,7 +214,7 @@ impl Document {
     /// Gets the descendants of the root document node in the current, filter by a matcher.
     /// It returns a new selection object containing elements of the single (first) match.    
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection {
-        let node = DescendantMatches::new(self.tree.root(), matcher, MatchScope::IncludeNode).next();
+        let node = DescendantMatches::new(self.tree.root(), matcher).next();
 
         match node {
             Some(node) => Selection { nodes: vec![node] },

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::entities::wrap_tendril;
-use crate::matcher::{MatchScope, Matcher, Matches};
+use crate::matcher::{MatchScope, Matcher, NodeMatches};
 use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.
@@ -206,7 +206,7 @@ impl Document {
     /// It returns a new selection object containing these matched elements.
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection {
         let root = self.tree.root();
-        let nodes = Matches::from_one(root, matcher, MatchScope::IncludeNode).collect();
+        let nodes = NodeMatches::new(root, matcher, MatchScope::IncludeNode).collect();
 
         Selection { nodes }
     }
@@ -214,7 +214,7 @@ impl Document {
     /// Gets the descendants of the root document node in the current, filter by a matcher.
     /// It returns a new selection object containing elements of the single (first) match.    
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection {
-        let node = Matches::from_one(self.tree.root(), matcher, MatchScope::IncludeNode).next();
+        let node = NodeMatches::new(self.tree.root(), matcher, MatchScope::IncludeNode).next();
 
         match node {
             Some(node) => Selection { nodes: vec![node] },

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -4,6 +4,7 @@ use std::ops::{Deref, DerefMut};
 
 use html5ever::LocalName;
 use html5ever::{namespace_url, ns, QualName};
+use selectors::context::SelectorCaches;
 use tendril::StrTendril;
 
 use crate::entities::{wrap_tendril, InnerHashMap};
@@ -18,6 +19,7 @@ use super::traversal::Traversal;
 /// An implementation of arena-tree.
 pub struct Tree {
     pub(crate) nodes: RefCell<Vec<TreeNode>>,
+    pub(crate) caches: RefCell<SelectorCaches>,
 }
 
 impl Debug for Tree {
@@ -31,6 +33,7 @@ impl Clone for Tree {
         let nodes = self.nodes.borrow();
         Self {
             nodes: RefCell::new(nodes.clone()),
+            caches: RefCell::new(SelectorCaches::default()),
         }
     }
 }
@@ -98,6 +101,7 @@ impl Tree {
         let root_id = NodeId::new(0);
         Self {
             nodes: RefCell::new(vec![TreeNode::new(root_id, root)]),
+            caches: RefCell::new(SelectorCaches::default()),
         }
     }
     /// Creates a new node with the given data.

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -4,7 +4,6 @@ use std::ops::{Deref, DerefMut};
 
 use html5ever::LocalName;
 use html5ever::{namespace_url, ns, QualName};
-use selectors::context::SelectorCaches;
 use tendril::StrTendril;
 
 use crate::entities::{wrap_tendril, InnerHashMap};
@@ -19,7 +18,6 @@ use super::traversal::Traversal;
 /// An implementation of arena-tree.
 pub struct Tree {
     pub(crate) nodes: RefCell<Vec<TreeNode>>,
-    pub(crate) caches: RefCell<SelectorCaches>,
 }
 
 impl Debug for Tree {
@@ -33,7 +31,6 @@ impl Clone for Tree {
         let nodes = self.nodes.borrow();
         Self {
             nodes: RefCell::new(nodes.clone()),
-            caches: RefCell::new(SelectorCaches::default()),
         }
     }
 }
@@ -101,7 +98,6 @@ impl Tree {
         let root_id = NodeId::new(0);
         Self {
             nodes: RefCell::new(vec![TreeNode::new(root_id, root)]),
-            caches: RefCell::new(SelectorCaches::default()),
         }
     }
     /// Creates a new node with the given data.

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -59,6 +59,7 @@ pub struct DescendantMatches<'a, 'b>{
 
 impl<'a, 'b> DescendantMatches<'a, 'b> {
     pub fn new(root_node: NodeRef<'a>, matcher: &'b Matcher) -> Self {
+        // Optimized for single-root node scenario - no duplicate checking needed
         let tree = root_node.tree;
         Self {
             iter: tree.descendant_ids_of_it(&root_node.id),
@@ -96,6 +97,7 @@ pub struct Matches<'a, 'b> {
 
 impl<'a, 'b> Matches<'a, 'b> {
     pub fn new<I: Iterator<Item = NodeRef<'a>>>(root_nodes: I, matcher: &'b Matcher) -> Self {
+        // Used for multiple root nodes where duplicate checking is necessary
         let nodes = root_nodes
             .flat_map(|node| node.children_it(true).filter(|n| n.is_element()))
             .collect();

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -60,13 +60,13 @@ impl <'a, 'b> NodeMatches<'a, 'b> {
         match match_scope {
             MatchScope::IncludeNode => {
                 Self {
-                    nodes: Box::new(iter::once(root_node.clone()).chain(root_node.descendants_it().filter(|n| n.is_element()))),
+                    nodes: Box::new(iter::once(root_node.clone()).chain(root_node.descendants_it())),
                     matcher
                 }
             },
             MatchScope::ChildrenOnly => {
                 Self {
-                    nodes: Box::new(root_node.descendants_it().filter(|n| n.is_element())),
+                    nodes: Box::new(root_node.descendants_it()),
                     matcher
                 }
             },
@@ -79,6 +79,9 @@ impl<'a> Iterator for NodeMatches<'a, '_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some(node) = self.nodes.next() {
+            if !node.is_element() {
+                continue;
+            }
 
             let mut caches = node.tree.caches.borrow_mut();
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -52,7 +52,6 @@ pub struct Matches<'a, 'b> {
     nodes: Vec<NodeRef<'a>>,
     matcher: &'b Matcher,
     seen: BitSet,
-    caches: SelectorCaches,
 }
 
 /// Telling a `matches` if we want to skip the roots.
@@ -81,7 +80,6 @@ impl<'a, 'b> Matches<'a, 'b> {
             nodes,
             matcher,
             seen: set,
-            caches: Default::default(),
         }
     }
 
@@ -97,7 +95,6 @@ impl<'a, 'b> Matches<'a, 'b> {
             nodes,
             matcher,
             seen: set,
-            caches: Default::default(),
         }
     }
 }
@@ -113,9 +110,11 @@ impl<'a> Iterator for Matches<'a, '_> {
             self.nodes
                 .extend(node.children_it(true).filter(|n| n.is_element()));
 
+            let mut caches = node.tree.caches.borrow_mut();
+
             if self
                 .matcher
-                .match_element_with_caches(&node, &mut self.caches)
+                .match_element_with_caches(&node, &mut caches)
             {
                 self.seen.insert(node.id.value);
                 return Some(node);
@@ -124,6 +123,7 @@ impl<'a> Iterator for Matches<'a, '_> {
         None
     }
 }
+
 
 pub(crate) struct InnerSelectorParser;
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -5,7 +5,7 @@ use cssparser::{CowRcStr, ParseError, SourceLocation, ToCss};
 use html5ever::Namespace;
 use selectors::context::SelectorCaches;
 use selectors::parser::{self, SelectorList, SelectorParseErrorKind};
-use selectors::{context, matching, visitor, Element};
+use selectors::{context, matching, Element};
 
 use crate::css::{CssLocalName, CssString};
 use crate::node::NodeRef;
@@ -279,13 +279,6 @@ impl parser::NonTSPseudoClass for NonTSPseudoClass {
     }
 
     fn is_user_action_state(&self) -> bool {
-        false
-    }
-
-    fn visit<V>(&self, _visitor: &mut V) -> bool
-    where
-        V: visitor::SelectorVisitor<Impl = Self::Impl>,
-    {
         false
     }
 }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -69,7 +69,7 @@ impl<'a> Iterator for DescendantMatches<'a, '_> {
     type Item = NodeRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(node) = self.nodes.next() {
+        for node in self.nodes.by_ref() {
             if !node.is_element() {
                 continue;
             }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -669,7 +669,7 @@ impl NodeRef<'_> {
     /// Checks if the node matches the given matcher
     pub fn is_match(&self, matcher: &Matcher) -> bool {
         self.is_element()
-            && matcher.match_element_with_caches(self, &mut self.tree.caches.borrow_mut())
+            && matcher.match_element(self)
     }
 
     /// Checks if the node matches the given selector

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -668,7 +668,8 @@ impl NodeRef<'_> {
 
     /// Checks if the node matches the given matcher
     pub fn is_match(&self, matcher: &Matcher) -> bool {
-        self.is_element() && matcher.match_element_with_caches(self, &mut self.tree.caches.borrow_mut())
+        self.is_element()
+            && matcher.match_element_with_caches(self, &mut self.tree.caches.borrow_mut())
     }
 
     /// Checks if the node matches the given selector

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -668,7 +668,7 @@ impl NodeRef<'_> {
 
     /// Checks if the node matches the given matcher
     pub fn is_match(&self, matcher: &Matcher) -> bool {
-        self.is_element() && matcher.match_element(self)
+        self.is_element() && matcher.match_element_with_caches(self, &mut self.tree.caches.borrow_mut())
     }
 
     /// Checks if the node matches the given selector

--- a/src/node/selector.rs
+++ b/src/node/selector.rs
@@ -26,7 +26,6 @@ impl selectors::Element for NodeRef<'_> {
     /// Converts self into an opaque representation. It can be crucial.
     #[inline]
     fn opaque(&self) -> OpaqueElement {
-        // TODO: ?
         let nodes = self.tree.nodes.borrow();
         let node = nodes.get(self.id.value).expect("element not in the tree!");
         OpaqueElement::new(node)

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,7 +6,7 @@ use html5ever::Attribute;
 use tendril::StrTendril;
 
 use crate::document::Document;
-use crate::matcher::{MatchScope, Matcher, Matches, DescendantMatches};
+use crate::matcher::{Matcher, Matches, DescendantMatches};
 use crate::node::{ancestor_nodes, child_nodes, format_text, NodeId, NodeRef, TreeNode};
 use crate::{Tree, TreeNodeOps};
 
@@ -363,7 +363,7 @@ impl<'a> Selection<'a> {
             return self.clone();
         }
         let root = self.nodes().first().unwrap().tree.root();
-        let other_nodes = DescendantMatches::new(root, matcher, MatchScope::IncludeNode).collect();
+        let other_nodes = DescendantMatches::new(root, matcher).collect();
         let new_nodes = self.merge_nodes(other_nodes);
         Selection { nodes: new_nodes }
     }
@@ -548,7 +548,7 @@ impl<'a> Selection<'a> {
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection<'a> {
         let nodes = if self.nodes().len() == 1 {
             let root_node = self.nodes()[0].clone();
-            DescendantMatches::new(root_node, matcher, MatchScope::ChildrenOnly).collect()
+            DescendantMatches::new(root_node, matcher).collect()
         } else {
             Matches::new(self.nodes.clone().into_iter().rev(), matcher).collect()
         };

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -585,11 +585,15 @@ impl<'a> Selection<'a> {
     /// elements, filter by a matcher. It returns a new Selection object
     /// containing elements of the single (first) match..
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection<'a> {
-        let node = Matches::new(self.nodes.clone().into_iter().rev(), matcher).next();
+        let node = if self.nodes().len() == 1 {
+            DescendantMatches::new(self.nodes()[0].clone(), matcher).next()
+        }else {
+            Matches::new(self.nodes.clone().into_iter().rev(), matcher).next()
+        };
 
         match node {
             Some(node) => Selection { nodes: vec![node] },
-            None => Selection { nodes: vec![] },
+            None => Selection::default(),
         }
     }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -215,7 +215,7 @@ impl<'a> Selection<'a> {
     /// returns true if at least one of these elements matches.
     pub fn is_matcher(&self, matcher: &Matcher) -> bool {
         if self.length() > 0 {
-            return self.nodes().iter().any(|node| matcher.match_element(node));
+            return self.nodes().iter().any(|node| matcher.match_element_with_caches(node, &mut node.tree.caches.borrow_mut()));
         }
         false
     }
@@ -284,7 +284,7 @@ impl<'a> Selection<'a> {
         let nodes = self
             .nodes()
             .iter()
-            .filter(|&node| matcher.match_element(node))
+            .filter(|&node| matcher.match_element_with_caches(node, &mut node.tree.caches.borrow_mut()))
             .cloned()
             .collect();
         Selection { nodes }

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -216,7 +216,7 @@ impl<'a> Selection<'a> {
     pub fn is_matcher(&self, matcher: &Matcher) -> bool {
         if self.length() > 0 {
             return self.nodes().iter().any(|node| {
-                matcher.match_element_with_caches(node, &mut node.tree.caches.borrow_mut())
+                matcher.match_element(node)
             });
         }
         false
@@ -287,7 +287,7 @@ impl<'a> Selection<'a> {
             .nodes()
             .iter()
             .filter(|&node| {
-                matcher.match_element_with_caches(node, &mut node.tree.caches.borrow_mut())
+                matcher.match_element(node)
             })
             .cloned()
             .collect();
@@ -546,6 +546,9 @@ impl<'a> Selection<'a> {
     /// elements, filter by a matcher. It returns a new Selection object
     /// containing these matched elements.
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection<'a> {
+        if self.is_empty() {
+            return Selection::default();
+        }
         let nodes = if self.nodes().len() == 1 {
             let root_node = self.nodes()[0].clone();
             DescendantMatches::new(root_node, matcher).collect()
@@ -585,6 +588,9 @@ impl<'a> Selection<'a> {
     /// elements, filter by a matcher. It returns a new Selection object
     /// containing elements of the single (first) match..
     pub fn select_single_matcher(&self, matcher: &Matcher) -> Selection<'a> {
+        if self.nodes.is_empty() {
+            return Selection::default();
+        }
         let node = if self.nodes().len() == 1 {
             DescendantMatches::new(self.nodes()[0].clone(), matcher).next()
         }else {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,7 +6,7 @@ use html5ever::Attribute;
 use tendril::StrTendril;
 
 use crate::document::Document;
-use crate::matcher::{MatchScope, Matcher, Matches};
+use crate::matcher::{MatchScope, Matcher, Matches, NodeMatches};
 use crate::node::{ancestor_nodes, child_nodes, format_text, NodeId, NodeRef, TreeNode};
 use crate::{Tree, TreeNodeOps};
 
@@ -543,14 +543,20 @@ impl<'a> Selection<'a> {
     /// elements, filter by a matcher. It returns a new Selection object
     /// containing these matched elements.
     pub fn select_matcher(&self, matcher: &Matcher) -> Selection<'a> {
-        Selection {
-            nodes: Matches::from_list(
+
+        let nodes = if self.nodes().len() == 1 {
+            let root_node = self.nodes()[0].clone();
+            NodeMatches::new(root_node, matcher, MatchScope::ChildrenOnly).collect()
+        }else {
+            Matches::from_list(
                 self.nodes.clone().into_iter().rev(),
                 matcher,
                 MatchScope::ChildrenOnly,
             )
-            .collect(),
-        }
+            .collect()
+        };
+
+        Selection {nodes}
     }
 
     /// Alias for `select`, it gets the descendants of each element in the current set of matched

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -158,7 +158,6 @@ fn test_descendants_bound() {
     assert_eq!(no_descendants_node.descendants_it().count(), 0);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_descendants_after_mod() {

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -585,3 +585,20 @@ fn test_selection_is_sorted() {
     let nodes_id_2 = sel_2.nodes().iter().map(|n| n.id).collect::<Vec<_>>();
     assert!(nodes_id_2.is_sorted());
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_select_single_ancestors() {
+    let doc: Document = ANCESTORS_CONTENTS.into();
+
+    let nonexisting_sel = doc.select("#ancestor").select("#parent").select_single("div");
+    assert!(!nonexisting_sel.exists());
+
+    let div_sel = doc.select_single("#great-ancestor").select_single("div");
+    assert!(div_sel.exists());
+
+    let p_sel = doc.select_single("#great-ancestor").select_single("p");
+    assert!(!p_sel.exists());
+    
+}


### PR DESCRIPTION
- Revised internal code related to element matching. Now, if there is only one root node, `DescendantMatches` (based on `DescendantNodes`) will be used as the internal iterator, which provides a faster approach and doesn't require an additional check for result duplicates. In the other case, `Matches` will be used, which, as previously, performs a check for duplicates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the descendant element selection and overall node matching process to enhance performance and maintain consistent behavior.

- **Tests**
  - Added assertions in the new test function to validate selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->