### PR TITLE
Revise `<NodeRef as selectors::Element>::is_link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+
 - Revised internal code related to element matching. Now, if there is only one root node, `DescendantMatches` (based on `DescendantNodes`) will be used as the internal iterator, which provides a faster approach and doesn't require an additional check for result duplicates. In the other case, `Matches` will be used, which, as previously, performs a check for duplicates.
+- Revised `<NodeRef as selectors::Element>::is_link`, which now always returns `false` since its effect on matching elements is unclear and it adds some overhead.
 
 ## [0.15.2] - 2025-03-06
 

--- a/src/node/selector.rs
+++ b/src/node/selector.rs
@@ -157,10 +157,10 @@ impl selectors::Element for NodeRef<'_> {
 
     /// Whether this element is a `link`.
     fn is_link(&self) -> bool {
-        // TODO: This function adds some overhead.
+        // This function adds some overhead.
         // Its purpose in dom_query is unclear.
         // Returning `false` works just fine.
-        self.query_or(false, |node| node.is_link())
+        false
     }
 
     /// Whether the element is an HTML element.


### PR DESCRIPTION
- Revised `<NodeRef as selectors::Element>::is_link`, which now always returns `false` since its effect on matching elements is unclear and it adds some overhead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced content processing performance by streamlining internal operations to handle elements more efficiently and reduce redundant checks, delivering a noticeably faster interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->