### PR TITLE
src/node/node_ref.rs: add new methods for `NodeRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Added
 - `NodeRef::element_ref` method, which returns a reference to the underlying `Element` if the node is an element node.
-- `NodeRef::text_data_ref` method, which returns a reference to the underlying text data if the node is a text node.
 - `NodeRef::qual_name_ref` method, which returns a reference to the qualified name of the node.
 - `NodeRef::has_name` method, which checks if the node is an element with the given local name.
 - `NodeRef::is_nonempty_text` method, which checks if the node is a non-empty text node.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `NodeRef::element_ref` method, which returns a reference to the underlying `Element` if the node is an element node.
+- `NodeRef::text_data_ref` method, which returns a reference to the underlying text data if the node is a text node.
+- `NodeRef::qual_name_ref` method, which returns a reference to the qualified name of the node.
+- `NodeRef::has_name` method, which checks if the node is an element with the given local name.
+- `NodeRef::is_nonempty_text` method, which checks if the node is a non-empty text node.
+
 ### Changed
 
 - Revised internal code related to element matching. Now, if there is only one root node, `DescendantMatches` (based on `DescendantNodes`) will be used as the internal iterator, which provides a faster approach and doesn't require an additional check for result duplicates. In the other case, `Matches` will be used, which, as previously, performs a check for duplicates.

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -742,21 +742,6 @@ impl <'a>NodeRef<'a> {
         .ok()
     }
 
-    /// Returns a reference to the text content of this node, if it is a text node.
-    ///
-    /// Returns `None` if the node is not a text node.
-    pub fn text_data_ref(&self) -> Option<Ref<'a, StrTendril>> {
-        Ref::filter_map(self.tree.nodes.borrow(), |nodes| {
-            let node = nodes.get(self.id.value)?;
-            if let NodeData::Text{ref contents} = node.data {
-                Some(contents)
-            } else {
-                None
-            }
-        })
-        .ok()
-    }
-
     /// Gets node's qualified name 
     pub fn qual_name_ref(&self) -> Option<Ref<'a, QualName>> {
         self.tree.get_name(&self.id)
@@ -775,7 +760,13 @@ impl <'a>NodeRef<'a> {
     /// Returns `true` if the node is a text node and its text content is not empty.
     /// Returns `false` if the node is not a text node or its text content is empty.
     pub fn is_nonempty_text(&self) -> bool {
-        self.text_data_ref().map_or(false, |text| !text.trim().is_empty())
+        self.query_or(false, |t| {
+            if let NodeData::Text { ref contents } = t.data {
+                !contents.trim().is_empty()
+            } else {
+                false
+            }
+        })
     }
 }
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -742,7 +742,9 @@ impl <'a>NodeRef<'a> {
         .ok()
     }
 
-    /// Gets node's qualified name 
+    /// Gets node's qualified name
+    /// 
+    /// Returns `None` if the node is not an element or the element name cannot be accessed.
     pub fn qual_name_ref(&self) -> Option<Ref<'a, QualName>> {
         self.tree.get_name(&self.id)
     }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -294,19 +294,6 @@ fn test_text_node_is() {
     assert!(!first_child.is("#text"));
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_text_ref() {
-    let doc = Document::from(ANCESTORS_CONTENTS);
-    let sel = doc.select_single("#first-child");
-    let node = sel.nodes().first().unwrap();
-    assert!(node.text_data_ref().is_none());
-    let first_child = node.first_child().unwrap();
-    let text_ref = first_child.text_data_ref();
-    assert!(text_ref.is_some());
-
-    assert_eq!(text_ref.unwrap().as_ref(), "Child");
-}
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -258,7 +258,6 @@ fn test_element_children() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_prev_sibling() {
     let doc = Document::from(ANCESTORS_CONTENTS);
-
     let last_child_sel = doc.select_single("#second-child");
     let last_child = last_child_sel.nodes().first().unwrap();
 
@@ -277,7 +276,6 @@ fn test_node_prev_sibling() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_is() {
     let doc = Document::from(ANCESTORS_CONTENTS);
-
     let parent_sel = doc.select_single("#parent");
     let parent_node = parent_sel.nodes().first().unwrap();
     assert!(parent_node.is("div#parent"));
@@ -288,13 +286,67 @@ fn test_node_is() {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_text_node_is() {
     let doc = Document::from(ANCESTORS_CONTENTS);
-
     let sel = doc.select_single("#first-child");
     let node = sel.nodes().first().unwrap();
     let first_child = node.first_child().unwrap();
     assert!(first_child.is_text());
 
     assert!(!first_child.is("#text"));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_text_ref() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+    let sel = doc.select_single("#first-child");
+    let node = sel.nodes().first().unwrap();
+    assert!(node.text_data_ref().is_none());
+    let first_child = node.first_child().unwrap();
+    let text_ref = first_child.text_data_ref();
+    assert!(text_ref.is_some());
+
+    assert_eq!(text_ref.unwrap().as_ref(), "Child");
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_is_nonempty_text() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+    let sel = doc.select_single("#first-child");
+    let node = sel.nodes().first().unwrap();
+    assert!(!node.is_nonempty_text());
+    let first_child = node.first_child().unwrap();
+    assert!(first_child.is_nonempty_text());
+
+    let body_sel = doc.select_single("body");
+    let body_node = body_sel.nodes().first().unwrap();
+    let body_first_child = body_node.first_child().unwrap();
+    assert!(body_first_child.is_text() && !body_first_child.is_nonempty_text());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_has_name() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+    let sel = doc.select_single("#first-child");
+    let node = sel.nodes().first().unwrap();
+    assert!(node.has_name("div"));
+    assert!(!node.has_name("p"));
+    let text_child = node.first_child().unwrap();
+    assert!(!text_child.has_name("div"));
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_get_qual_name() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+    let sel = doc.select_single("#first-child");
+    let node = sel.nodes().first().unwrap();
+    let node_qual_name = node.qual_name_ref().unwrap();
+    assert_eq!(node_qual_name.local.as_ref(), "div");
+    assert_ne!(node_qual_name.local.as_ref(), "p");
+    let text_child = node.first_child().unwrap();
+    assert!(!text_child.has_name("div"));
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]


### PR DESCRIPTION
- `NodeRef::element_ref` method, which returns a reference to the underlying `Element` if the node is an element node.
- `NodeRef::qual_name_ref` method, which returns a reference to the qualified name of the node.
- `NodeRef::has_name` method, which checks if the node is an element with the given local name.
- `NodeRef::is_nonempty_text` method, which checks if the node is a non-empty text node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced node inspection capabilities, allowing for detailed evaluation of element and text content.
  - Optimized processing for documents with a single root, resulting in improved performance.
  - Streamlined link detection behavior for more consistent handling.

- **Tests**
  - Expanded test coverage with new tests for non-empty text nodes, node name verification, and qualified name checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->