### PR TITLE
Introduced the `NodeRef::strip_elements(&[&str])`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Introduced the `NodeRef::strip_elements(&[&str])` method, which removes matched elements while retaining their children in the document tree.
+- Introduced the `Selection::strip_elements(&[&str])` method, which does the same operation as `NodeRef::strip_elements(&[&str])` but for every node in the `Selection`.
+
 ## [0.16.0] - 2025-03-09
 
 ### Added

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -675,6 +675,9 @@ impl NodeRef<'_> {
     /// # Arguments
     /// * `names` - A list of element names to strip.
     pub fn strip_elements(&self, names: &[&str]) {
+        if names.is_empty() {
+            return;
+        }
         let mut child = self.first_child();
 
         while let Some(ref child_node) = child {

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -668,6 +668,12 @@ impl NodeRef<'_> {
         }
     }
 
+    /// Strips all elements with the specified names from the node's descendants.
+    /// 
+    /// If matched element has children, they will be assigned to the parent of the matched element.
+    /// 
+    /// # Arguments
+    /// * `names` - A list of element names to strip.
     pub fn strip_elements(&self, names: &[&str]) {
         let mut child = self.first_child();
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -668,6 +668,28 @@ impl NodeRef<'_> {
         }
     }
 
+    pub fn strip_elements(&self, names: &[&str]) {
+        let mut child = self.first_child();
+
+        while let Some(ref child_node) = child {
+            let next_node = child_node.next_sibling();
+            if child_node.may_have_children() {
+                child_node.strip_elements(names);
+            }
+            if !child_node.is_element() {
+                child = next_node;
+                continue;
+            }
+            if child_node.qual_name_ref().map_or(false,|name| names.contains(&name.local.as_ref())) {
+                if let Some(first_inline) = child_node.first_child(){
+                    child_node.insert_siblings_before(&first_inline);
+                };
+                child_node.remove_from_parent();
+            }
+            child = next_node;
+        }
+    }
+
 }
 
 impl NodeRef<'_> {

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -95,6 +95,17 @@ impl Selection<'_> {
         });
     }
 
+    /// Removes matching elements from the descendants, but keeps their children (if any) in the tree.
+    /// 
+    /// Unlike [`Self::remove`], this method only deletes the elements themselves, promoting their children
+    /// to the parent level, thus preserving the nested structure of the remaining nodes.
+    /// 
+    /// # Arguments
+    /// * `names` - A list of element names to strip.
+    pub fn strip_elements(&self, names: &[&str]) {
+        self.nodes().iter().for_each(|node| node.strip_elements(names))
+    }
+
     /// Returns the id of the first element in the set of matched elements.
     pub fn id(&self) -> Option<StrTendril> {
         self.nodes().first().and_then(|node| node.id_attr())

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -680,6 +680,11 @@ fn test_node_strip_elements() {
 
     let sel = doc.select("body");
     let node = sel.nodes().first().unwrap();
+    let descendants_before = node.descendants();
+    // nothing to strip, so nothing should change
+    node.strip_elements(&[]);
+    assert_eq!(descendants_before.len(), node.descendants().len());
+    // stripping all div elements inside `body`
     node.strip_elements(&["div"]);
     assert_eq!(doc.select("body div").length(), 0);
     assert_eq!(doc.select("body").text().matches("Child").count(), 2);

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -671,3 +671,16 @@ fn test_node_rename() {
     assert_eq!(doc.select("#parent div").length(), 1);
     assert_eq!(doc.select("#parent p").length(), 1);
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_strip_elements() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("body");
+    let node = sel.nodes().first().unwrap();
+    node.strip_elements(&["div"]);
+    assert_eq!(doc.select("body div").length(), 0);
+    assert_eq!(doc.select("body").text().matches("Child").count(), 2);
+} 

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -330,3 +330,30 @@ fn test_prepend_another_tree_selection() {
         2
     );
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_selection_strip_elements() {
+
+    let contents = r#"<!DOCTYPE html>
+    <html lang="en">
+        <head></head>
+        <body>
+            <ul>
+                <li><span><b><i>First</i></b></span></li>
+                <li><span><b><i>Second</i></b></span></li>
+                <li><span><b><i>Third</i></b></span></li>
+            </ul>
+        </body>
+    "#;
+    let doc = Document::from(contents);
+
+    let sel = doc.select("li");
+    assert_eq!(sel.length(), 3);
+    assert_eq!(sel.select("span b i").length(), 3);
+
+    sel.strip_elements(&["span", "i"]);
+    assert_eq!(sel.select("span, i").length(), 0);
+    assert_eq!(sel.select("b").length(), 3);
+
+} 


### PR DESCRIPTION
- Introduced the `NodeRef::strip_elements(&[&str])` method, which removes matched elements while retaining their children in the document tree.
- Introduced the `Selection::strip_elements(&[&str])` method, which does the same operation as `NodeRef::strip_elements(&[&str])` but for every node in the `Selection`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced document manipulation capabilities that allow for targeted removal of specific elements while keeping their inner content intact.
- **Tests**
  - Expanded test coverage to ensure reliable performance of the new `strip_elements` functionality for both nodes and selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->