### PR TITLE
added `NodeRef::retain_attrs` and `Selecttion::retain_attrs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Added
 - Introduced the `NodeRef::strip_elements(&[&str])` method, which removes matched elements while retaining their children in the document tree.
-- Introduced the `Selection::strip_elements(&[&str])` method, which does the same operation as `NodeRef::strip_elements(&[&str])` but for every node in the `Selection`.
+- Introduced the `Selection::strip_elements(&[&str])` method, which performs the same operation as `NodeRef::strip_elements(&[&str])` but for every node in the `Selection`.
+- Introduced the `NodeRef::retain_attrs` method, which allows retaining only the specified attributes of a node.
+- Introduced the `Selection::retain_attrs` method, which performs the same operation as `NodeRef::retain_attrs` but for every node in the `Selection`.
 
 ## [0.16.0] - 2025-03-09
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,7 +12,7 @@ use tendril::{StrTendril, TendrilSink};
 
 use crate::dom_tree::Tree;
 use crate::entities::wrap_tendril;
-use crate::matcher::{Matcher, DescendantMatches};
+use crate::matcher::{DescendantMatches, Matcher};
 use crate::node::{Element, NodeData, NodeId, NodeRef, TreeNode};
 use crate::selection::Selection;
 /// Document represents an HTML document to be manipulated.

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -49,8 +49,7 @@ impl Matcher {
     }
 }
 
-
-pub struct DescendantMatches<'a, 'b>{
+pub struct DescendantMatches<'a, 'b> {
     iter: DescendantNodes<'a>,
     matcher: &'b Matcher,
     caches: SelectorCaches,
@@ -65,7 +64,7 @@ impl<'a, 'b> DescendantMatches<'a, 'b> {
             iter: tree.descendant_ids_of_it(&root_node.id),
             matcher,
             caches: SelectorCaches::default(),
-            tree
+            tree,
         }
     }
 }
@@ -79,7 +78,10 @@ impl<'a> Iterator for DescendantMatches<'a, '_> {
             if !node.is_element() {
                 continue;
             }
-            if self.matcher.match_element_with_caches(&node, &mut self.caches) {
+            if self
+                .matcher
+                .match_element_with_caches(&node, &mut self.caches)
+            {
                 return Some(node);
             }
         }
@@ -93,7 +95,6 @@ pub struct Matches<'a, 'b> {
     seen: BitSet,
     caches: SelectorCaches,
 }
-
 
 impl<'a, 'b> Matches<'a, 'b> {
     pub fn new<I: Iterator<Item = NodeRef<'a>>>(root_nodes: I, matcher: &'b Matcher) -> Self {
@@ -122,7 +123,10 @@ impl<'a> Iterator for Matches<'a, '_> {
             self.nodes
                 .extend(node.children_it(true).filter(|n| n.is_element()));
 
-            if self.matcher.match_element_with_caches(&node, &mut self.caches) {
+            if self
+                .matcher
+                .match_element_with_caches(&node, &mut self.caches)
+            {
                 self.seen.insert(node.id.value);
                 return Some(node);
             }

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -114,7 +114,7 @@ impl TreeNode {
     }
 
     /// Removes the specified attributes from the element.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&mut self, names: &[&str]) {
@@ -124,7 +124,7 @@ impl TreeNode {
     }
 
     /// Retains only the attributes with the specified names.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
     pub fn retain_attrs(&mut self, names: &[&str]) {

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -114,9 +114,22 @@ impl TreeNode {
     }
 
     /// Removes the specified attributes from the element.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&mut self, names: &[&str]) {
         if let Some(element) = self.as_element_mut() {
             element.remove_attrs(names);
+        }
+    }
+
+    /// Retains only the attributes with the specified names.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
+    pub fn retain_attrs(&mut self, names: &[&str]) {
+        if let Some(element) = self.as_element_mut() {
+            element.retain_attrs(names);
         }
     }
 

--- a/src/node/node_data.rs
+++ b/src/node/node_data.rs
@@ -222,23 +222,21 @@ impl Element {
     }
 
     /// Removes the specified attributes from the element.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&mut self, names: &[&str]) {
-        self.attrs.retain(|attr| {
-            !names.contains(&attr.name.local.as_ref())
-        });
+        self.attrs
+            .retain(|attr| !names.contains(&attr.name.local.as_ref()));
     }
 
     /// Retains only the attributes with the specified names.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
     pub fn retain_attrs(&mut self, names: &[&str]) {
-        self.attrs.retain(|a| {
-            names.contains(&a.name.local.as_ref())
-        });
+        self.attrs
+            .retain(|a| names.contains(&a.name.local.as_ref()));
     }
 
     /// Removes all attributes from the element.

--- a/src/node/node_data.rs
+++ b/src/node/node_data.rs
@@ -222,10 +222,22 @@ impl Element {
     }
 
     /// Removes the specified attributes from the element.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&mut self, names: &[&str]) {
         self.attrs.retain(|attr| {
-            let name_local: &str = &attr.name.local;
-            !names.contains(&name_local)
+            !names.contains(&attr.name.local.as_ref())
+        });
+    }
+
+    /// Retains only the attributes with the specified names.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
+    pub fn retain_attrs(&mut self, names: &[&str]) {
+        self.attrs.retain(|a| {
+            names.contains(&a.name.local.as_ref())
         });
     }
 

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -456,7 +456,7 @@ impl NodeRef<'_> {
     }
 
     /// Removes the specified attributes from the element.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&self, names: &[&str]) {
@@ -464,7 +464,7 @@ impl NodeRef<'_> {
     }
 
     /// Retains only the attributes with the specified names.
-    /// 
+    ///
     /// # Arguments
     /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
     pub fn retain_attrs(&self, names: &[&str]) {
@@ -680,9 +680,9 @@ impl NodeRef<'_> {
     }
 
     /// Strips all elements with the specified names from the node's descendants.
-    /// 
+    ///
     /// If matched element has children, they will be assigned to the parent of the matched element.
-    /// 
+    ///
     /// # Arguments
     /// * `names` - A list of element names to strip.
     pub fn strip_elements(&self, names: &[&str]) {
@@ -700,8 +700,11 @@ impl NodeRef<'_> {
                 child = next_node;
                 continue;
             }
-            if child_node.qual_name_ref().map_or(false,|name| names.contains(&name.local.as_ref())) {
-                if let Some(first_inline) = child_node.first_child(){
+            if child_node
+                .qual_name_ref()
+                .map_or(false, |name| names.contains(&name.local.as_ref()))
+            {
+                if let Some(first_inline) = child_node.first_child() {
                     child_node.insert_siblings_before(&first_inline);
                 };
                 child_node.remove_from_parent();
@@ -709,14 +712,12 @@ impl NodeRef<'_> {
             child = next_node;
         }
     }
-
 }
 
 impl NodeRef<'_> {
     /// Checks if the node matches the given matcher
     pub fn is_match(&self, matcher: &Matcher) -> bool {
-        self.is_element()
-            && matcher.match_element(self)
+        self.is_element() && matcher.match_element(self)
     }
 
     /// Checks if the node matches the given selector
@@ -764,11 +765,9 @@ impl NodeRef<'_> {
         let nodes = self.tree.nodes.borrow();
         TreeNodeOps::normalized_char_count(nodes, self.id)
     }
-
 }
 
-
-impl <'a>NodeRef<'a> {
+impl<'a> NodeRef<'a> {
     /// Returns a reference to the element node that this node references, if it is an element.
     ///
     /// Returns `None` if the node is not an element.
@@ -785,7 +784,7 @@ impl <'a>NodeRef<'a> {
     }
 
     /// Gets node's qualified name
-    /// 
+    ///
     /// Returns `None` if the node is not an element or the element name cannot be accessed.
     pub fn qual_name_ref(&self) -> Option<Ref<'a, QualName>> {
         self.tree.get_name(&self.id)
@@ -813,8 +812,6 @@ impl <'a>NodeRef<'a> {
         })
     }
 }
-
-
 
 #[cfg(feature = "markdown")]
 impl NodeRef<'_> {

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -456,8 +456,19 @@ impl NodeRef<'_> {
     }
 
     /// Removes the specified attributes from the element.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&self, names: &[&str]) {
         self.update(|node| node.remove_attrs(names));
+    }
+
+    /// Retains only the attributes with the specified names.
+    /// 
+    /// # Arguments
+    /// - `names`: A slice of attribute names to retain. Empty slice retains no attributes.
+    pub fn retain_attrs(&self, names: &[&str]) {
+        self.update(|node| node.retain_attrs(names));
     }
 
     /// Removes all attributes from the element.

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -6,7 +6,7 @@ use html5ever::Attribute;
 use tendril::StrTendril;
 
 use crate::document::Document;
-use crate::matcher::{Matcher, Matches, DescendantMatches};
+use crate::matcher::{DescendantMatches, Matcher, Matches};
 use crate::node::{ancestor_nodes, child_nodes, format_text, NodeId, NodeRef, TreeNode};
 use crate::{Tree, TreeNodeOps};
 
@@ -75,7 +75,7 @@ impl Selection<'_> {
     }
 
     /// Removes named attributes from each element in the set of matched elements.
-    /// 
+    ///
     /// # Arguments
     /// * `names` - A list of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&self, names: &[&str]) {
@@ -85,7 +85,7 @@ impl Selection<'_> {
     }
 
     /// Retains only the attributes with the specified names from each element in the set of matched elements.
-    /// 
+    ///
     /// # Arguments
     /// * `names` - A list of attribute names to retain. Empty slice retains no attributes.
     pub fn retain_attrs(&self, names: &[&str]) {
@@ -109,14 +109,16 @@ impl Selection<'_> {
     }
 
     /// Removes matching elements from the descendants, but keeps their children (if any) in the tree.
-    /// 
+    ///
     /// Unlike [`Self::remove`], this method only deletes the elements themselves, promoting their children
     /// to the parent level, thus preserving the nested structure of the remaining nodes.
-    /// 
+    ///
     /// # Arguments
     /// * `names` - A list of element names to strip.
     pub fn strip_elements(&self, names: &[&str]) {
-        self.nodes().iter().for_each(|node| node.strip_elements(names))
+        self.nodes()
+            .iter()
+            .for_each(|node| node.strip_elements(names))
     }
 
     /// Returns the id of the first element in the set of matched elements.
@@ -239,9 +241,7 @@ impl<'a> Selection<'a> {
     /// returns true if at least one of these elements matches.
     pub fn is_matcher(&self, matcher: &Matcher) -> bool {
         if self.length() > 0 {
-            return self.nodes().iter().any(|node| {
-                matcher.match_element(node)
-            });
+            return self.nodes().iter().any(|node| matcher.match_element(node));
         }
         false
     }
@@ -310,9 +310,7 @@ impl<'a> Selection<'a> {
         let nodes = self
             .nodes()
             .iter()
-            .filter(|&node| {
-                matcher.match_element(node)
-            })
+            .filter(|&node| matcher.match_element(node))
             .cloned()
             .collect();
         Selection { nodes }
@@ -617,7 +615,7 @@ impl<'a> Selection<'a> {
         }
         let node = if self.nodes().len() == 1 {
             DescendantMatches::new(self.nodes()[0].clone(), matcher).next()
-        }else {
+        } else {
             Matches::new(self.nodes.clone().into_iter().rev(), matcher).next()
         };
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -75,9 +75,22 @@ impl Selection<'_> {
     }
 
     /// Removes named attributes from each element in the set of matched elements.
+    /// 
+    /// # Arguments
+    /// * `names` - A list of attribute names to remove. Empty slice removes no attributes.
     pub fn remove_attrs(&self, names: &[&str]) {
         self.update_nodes(|tree_node| {
             tree_node.remove_attrs(names);
+        });
+    }
+
+    /// Retains only the attributes with the specified names from each element in the set of matched elements.
+    /// 
+    /// # Arguments
+    /// * `names` - A list of attribute names to retain. Empty slice retains no attributes.
+    pub fn retain_attrs(&self, names: &[&str]) {
+        self.update_nodes(|tree_node| {
+            tree_node.retain_attrs(names);
         });
     }
 

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -642,9 +642,22 @@ fn test_node_remove_attrs() {
 
     let sel = doc.select("#parent [class][id]");
     assert_eq!(sel.length(), 2);
-    let node = sel.nodes().first().unwrap();
-    node.remove_attrs(&["class", "id"]);
+    let first_child = sel.nodes().first().unwrap();
+    first_child.remove_attrs(&["class", "id"]);
     assert_eq!(doc.select("#parent [class][id]").length(), 1);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_retain_attrs() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("#parent [class][id]");
+    assert_eq!(sel.length(), 2);
+    let node = sel.nodes().first().unwrap();
+    node.retain_attrs(&["id"]);
+    assert_eq!(doc.select("#parent [class][id]").length(), 1);
+    assert_eq!(doc.select("#parent [id]").length(), 2);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -685,7 +685,6 @@ fn test_node_rename() {
     assert_eq!(doc.select("#parent p").length(), 1);
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_strip_elements() {
@@ -701,4 +700,4 @@ fn test_node_strip_elements() {
     node.strip_elements(&["div"]);
     assert_eq!(doc.select("body div").length(), 0);
     assert_eq!(doc.select("body").text().matches("Child").count(), 2);
-} 
+}

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -294,7 +294,6 @@ fn test_text_node_is() {
     assert!(!first_child.is("#text"));
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_is_nonempty_text() {

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -1,7 +1,7 @@
 mod data;
 
 use data::{
-    doc_with_siblings, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS, REPLACEMENT_SEL_CONTENTS,
+    doc_with_siblings, ATTRS_CONTENTS, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS, REPLACEMENT_SEL_CONTENTS
 };
 use dom_query::Document;
 
@@ -355,5 +355,32 @@ fn test_selection_strip_elements() {
     sel.strip_elements(&["span", "i"]);
     assert_eq!(sel.select("span, i").length(), 0);
     assert_eq!(sel.select("b").length(), 3);
-
 } 
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_retain_attrs() {
+    let doc: Document = ATTRS_CONTENTS.into();
+    let font_sel = doc.select("[face][size][color]");
+    assert_eq!(font_sel.length(), 3);
+    font_sel.retain_attrs(&["size"]);
+    assert_eq!(doc.select("[face][size][color]").length(), 0);
+    assert_eq!(doc.select("[size]").length(), 3);
+
+    font_sel.retain_attrs(&[]);
+    assert_eq!(doc.select("[size]").length(), 0);    
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_remove_attrs() {
+    let doc: Document = ATTRS_CONTENTS.into();
+    let font_sel = doc.select("[face][size][color]");
+    assert_eq!(font_sel.length(), 3);
+    font_sel.remove_attrs(&["size"]);
+    assert_eq!(doc.select("[face][size][color]").length(), 0);
+    assert_eq!(doc.select("[face][color]").length(), 3);
+
+    font_sel.remove_attrs(&[]);
+    assert_eq!(doc.select("[face][color]").length(), 3);    
+}

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -1,7 +1,8 @@
 mod data;
 
 use data::{
-    doc_with_siblings, ATTRS_CONTENTS, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS, REPLACEMENT_SEL_CONTENTS
+    doc_with_siblings, ATTRS_CONTENTS, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS,
+    REPLACEMENT_SEL_CONTENTS,
 };
 use dom_query::Document;
 
@@ -334,7 +335,6 @@ fn test_prepend_another_tree_selection() {
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_selection_strip_elements() {
-
     let contents = r#"<!DOCTYPE html>
     <html lang="en">
         <head></head>
@@ -355,7 +355,7 @@ fn test_selection_strip_elements() {
     sel.strip_elements(&["span", "i"]);
     assert_eq!(sel.select("span, i").length(), 0);
     assert_eq!(sel.select("b").length(), 3);
-} 
+}
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
@@ -368,7 +368,7 @@ fn test_retain_attrs() {
     assert_eq!(doc.select("[size]").length(), 3);
 
     font_sel.retain_attrs(&[]);
-    assert_eq!(doc.select("[size]").length(), 0);    
+    assert_eq!(doc.select("[size]").length(), 0);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -382,5 +382,5 @@ fn test_remove_attrs() {
     assert_eq!(doc.select("[face][color]").length(), 3);
 
     font_sel.remove_attrs(&[]);
-    assert_eq!(doc.select("[face][color]").length(), 3);    
+    assert_eq!(doc.select("[face][color]").length(), 3);
 }

--- a/tests/selection-property.rs
+++ b/tests/selection-property.rs
@@ -182,27 +182,6 @@ fn test_remove_class_similar() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-fn test_remove_attrs() {
-    let doc: Document = r#"<!DOCTYPE html>
-    <html>
-        <head><title>Test</title></head>
-        <body>
-            <div id="main" class="main" style="color:green;">Green content</div>
-        <body>
-    </html>"#
-        .into();
-    let sel = doc.select("div#main");
-
-    sel.remove_attrs(&["id", "style"]);
-
-    assert_eq!(
-        sel.html(),
-        r#"<div class="main">Green content</div>"#.into()
-    );
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), test)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_has_attr() {
     let doc: Document = r#"<!DOCTYPE html>
     <html>

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -586,13 +586,15 @@ fn test_selection_is_sorted() {
     assert!(nodes_id_2.is_sorted());
 }
 
-
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_select_single_ancestors() {
     let doc: Document = ANCESTORS_CONTENTS.into();
 
-    let nonexisting_sel = doc.select("#ancestor").select("#parent").select_single("div");
+    let nonexisting_sel = doc
+        .select("#ancestor")
+        .select("#parent")
+        .select_single("div");
     assert!(!nonexisting_sel.exists());
 
     let div_sel = doc.select_single("#great-ancestor").select_single("div");
@@ -600,5 +602,4 @@ fn test_select_single_ancestors() {
 
     let p_sel = doc.select_single("#great-ancestor").select_single("p");
     assert!(!p_sel.exists());
-    
 }


### PR DESCRIPTION
- Introduced the `NodeRef::retain_attrs` method, which allows retaining only the specified attributes of a node.
- Introduced the `Selection::retain_attrs` method, which performs the same operation as `NodeRef::retain_attrs` but for every node in the `Selection`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to selectively retain specific attributes on elements and selections, offering more granular control over attribute management.
- **Tests**
  - Expanded test coverage to validate the new attribute filtering capabilities and removed redundant tests for enhanced efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->