### PR TITLE
Improved `mini_selector::Attribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Changed
 - Updated `selectors` dependency to version 0.27.0.
 - Updated `cssparser` dependency to version 0.35.0.
+- Updated `html5ever` dependency to version 0.31.0.
+- Improved `mini_selector::Attribute`: attribute values can now be enclosed in either double or single quotes, or left unquoted.
 
 ## [0.17.0] - 2025-03-31
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [".*", "test-pages"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-html5ever = "0.30.0"
+html5ever = "0.31.0"
 selectors = "0.27.0"
 cssparser = "0.35.0"
 tendril = "0.4.3"

--- a/src/mini_selector/parser.rs
+++ b/src/mini_selector/parser.rs
@@ -67,7 +67,6 @@ fn parse_attr_value(input: &str) -> IResult<&str, AttrValue> {
         preceded(char('"'), cut(terminated(is_not("\""), char('"')))),
         preceded(char('\''), cut(terminated(is_not("\'"), char('\'')))),
         take_while1(|c: char| c != ']'),
-        //take_while1(|c: char| !c.is_whitespace() && c != ']' && c != '"' && c != '\''),
     )).parse(input)?;
     Ok((input, AttrValue { op, value }))
 }

--- a/src/mini_selector/selector.rs
+++ b/src/mini_selector/selector.rs
@@ -28,7 +28,7 @@ pub(crate) struct AttrValue<'a> {
     pub value: &'a str,
 }
 
-impl<'a> AttrValue<'a> {
+impl AttrValue<'_> {
     pub(crate) fn is_match(&self, elem_value: &str) -> bool {
         if elem_value.is_empty() {
             return false;

--- a/tests/selection-query.rs
+++ b/tests/selection-query.rs
@@ -17,7 +17,6 @@ fn test_is() {
     let sel = doc.select(".footer p:nth-child(1)");
     assert!(sel.is("p"), "Expected .footer p:nth-child(1) to be a p.");
     assert!(!doc.select("#non-existing").is("#non-existing"));
-
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]


### PR DESCRIPTION
- Improved `mini_selector::Attribute`: attribute values can now be enclosed in either double or single quotes, or left unquoted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced attribute selection with flexible support for double quotes, single quotes, or unquoted values.
- **Refactor**
  - Streamlined the attribute matching logic by consolidating operator and value handling for improved consistency.
- **Chores**
  - Upgraded the HTML parsing dependency to version 0.31.0, improving functionality and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->