### PR TITLE
Adding wrap_node(), wrap_html(), and unwrap_node()

### DIFF
--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -369,11 +369,11 @@ impl NodeRef<'_> {
         TreeNodeOps::remove_from_parent(&mut nodes, wrapper_id);
 
         // Insert wrapper before self in the parent
-        TreeNodeOps::insert_before_of(&mut nodes, &self.id, &wrapper_id);
+        TreeNodeOps::insert_before_of(&mut nodes, &self.id, wrapper_id);
 
         // Move self into wrapper as the only child
         TreeNodeOps::remove_from_parent(&mut nodes, &self.id);
-        TreeNodeOps::append_child_of(&mut nodes, &wrapper_id, &self.id);
+        TreeNodeOps::append_child_of(&mut nodes, wrapper_id, &self.id);
     }
 
     /// Wraps the current node with the given HTML fragment.

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -365,9 +365,6 @@ impl NodeRef<'_> {
         let wrapper_id = new_parent.node_id();
         let mut nodes = self.tree.nodes.borrow_mut();
 
-        // Remove wrapper from any existing parent
-        TreeNodeOps::remove_from_parent(&mut nodes, wrapper_id);
-
         // Insert wrapper before self in the parent
         TreeNodeOps::insert_before_of(&mut nodes, &self.id, wrapper_id);
 
@@ -392,7 +389,7 @@ impl NodeRef<'_> {
         });
     }
 
-    /// Unwrap the node from its parent, removing the parent node from the tree.
+    /// Unwrap the node (and it's siblings) from its parent, removing the parent node from the tree.
     /// If the parent does not exist or is not an element, it does nothing.
     pub fn unwrap_node(&self) {
         if let Some(parent) = self.parent() {
@@ -400,13 +397,12 @@ impl NodeRef<'_> {
                 return; // Only unwrap if parent is an element
             }
 
-            if let Some(_grandparent) = parent.parent() {
-                // Insert self before parent in grandparent's children
-                parent.insert_before(self);
+            // We can unwrap if there is a grandparent to hold the unwrapped nodes
+            if parent.parent().is_some() {
+                // Insert self and siblings before parent in grandparent's children
+                parent.insert_siblings_before(self);
                 // Remove parent from the tree
                 parent.remove_from_parent();
-            } else {
-                // Parent has no parent (e.g., parent is root) => no unwrap possible
             }
         }
     }

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -358,6 +358,58 @@ impl NodeRef<'_> {
             },
         );
     }
+
+    /// Wraps the current node in a new parent element.
+    /// The parent node becomes the parent of the current node, replacing it in the original structure.
+    pub fn wrap_node<P: NodeIdProver>(&self, new_parent: P) {
+        let wrapper_id = new_parent.node_id();
+        let mut nodes = self.tree.nodes.borrow_mut();
+
+        // Remove wrapper from any existing parent
+        TreeNodeOps::remove_from_parent(&mut nodes, wrapper_id);
+
+        // Insert wrapper before self in the parent
+        TreeNodeOps::insert_before_of(&mut nodes, &self.id, &wrapper_id);
+
+        // Move self into wrapper as the only child
+        TreeNodeOps::remove_from_parent(&mut nodes, &self.id);
+        TreeNodeOps::append_child_of(&mut nodes, &wrapper_id, &self.id);
+    }
+
+    /// Wraps the current node with the given HTML fragment.
+    /// The outermost node of the fragment becomes the new parent of the current node.
+    pub fn wrap_html<T>(&self, html: T)
+    where
+        T: Into<StrTendril>,
+    {
+        self.merge_html_with_fn(html, |tree_nodes, wrapper_id, node| {
+            // Insert wrapper before the node
+            TreeNodeOps::insert_before_of(tree_nodes, &node.id, &wrapper_id);
+            // Remove node from current parent
+            TreeNodeOps::remove_from_parent(tree_nodes, &node.id);
+            // Append node into wrapper
+            TreeNodeOps::append_child_of(tree_nodes, &wrapper_id, &node.id);
+        });
+    }
+
+    /// Unwrap the node from its parent, removing the parent node from the tree.
+    /// If the parent does not exist or is not an element, it does nothing.
+    pub fn unwrap_node(&self) {
+        if let Some(parent) = self.parent() {
+            if !parent.is_element() {
+                return; // Only unwrap if parent is an element
+            }
+
+            if let Some(_grandparent) = parent.parent() {
+                // Insert self before parent in grandparent's children
+                parent.insert_before(self);
+                // Remove parent from the tree
+                parent.remove_from_parent();
+            } else {
+                // Parent has no parent (e.g., parent is root) => no unwrap possible
+            }
+        }
+    }
 }
 
 impl NodeRef<'_> {

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -726,6 +726,28 @@ fn test_node_wrap_node() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_wrap_node_existing() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("#first-child");
+    let node = sel.nodes().first().unwrap();
+
+    // Use the second-child as a wrapper
+    let wrapper_sel = doc.select("#second-child");
+    let wrapper = wrapper_sel.nodes().first().unwrap();
+
+    node.wrap_node(wrapper);
+
+    // Wrapper should now exist
+    assert_eq!(doc.select("#parent #second-child").length(), 1);
+    // Wrapper should contain the first-child
+    assert_eq!(doc.select("#second-child > #first-child").length(), 1);
+    // Parent should only have one child, the second-child wrapper
+    assert_eq!(doc.select("#parent > *").length(), 1);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_node_wrap_html() {
     let doc = Document::from(ANCESTORS_CONTENTS);
 
@@ -762,11 +784,9 @@ fn test_node_unwrap_node() {
     // The parent of #first-child (id="parent") should be removed
     assert!(doc.select("#parent").is_empty());
 
-    // The grand-parent (id="grand-parent") should now directly contain #first-child
+    // The grand-parent (id="grand-parent") should now directly contain #first-child and #second-child
     assert_eq!(doc.select("#grand-parent > #first-child").length(), 1);
-
-    // #second-child should also be removed with #parent
-    assert!(doc.select("#second-child").is_empty());
+    assert_eq!(doc.select("#grand-parent > #second-child").length(), 1);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -701,3 +701,83 @@ fn test_node_strip_elements() {
     assert_eq!(doc.select("body div").length(), 0);
     assert_eq!(doc.select("body").text().matches("Child").count(), 2);
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_wrap_node() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("#first-child");
+    let node = sel.nodes().first().unwrap();
+
+    // Create a wrapper directly in the same tree
+    let wrapper = doc.tree.new_element("div");
+    wrapper.set_attr("id", "wrapper");
+
+    node.wrap_node(&wrapper);
+
+    // Wrapper should now exist
+    assert_eq!(doc.select("#parent #wrapper").length(), 1);
+    // Wrapper should contain the first-child
+    assert_eq!(doc.select("#wrapper > #first-child").length(), 1);
+    // Parent should still have two children, one being the wrapper
+    assert_eq!(doc.select("#parent > *").length(), 2);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_wrap_html() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("#first-child");
+    let node = sel.nodes().first().unwrap();
+
+    // Wrap with an HTML fragment
+    node.wrap_html("<div id='wrapper-html' class='wrapper'></div>");
+
+    // Check wrapper exists in the DOM
+    assert_eq!(doc.select("#parent #wrapper-html").length(), 1);
+
+    // Check the wrapper contains the original node
+    assert_eq!(doc.select("#wrapper-html > #first-child").length(), 1);
+
+    // The wrapper should have class attribute
+    let wrapper_sel = doc.select("#wrapper-html");
+    let wrapper_node = wrapper_sel.nodes().first().unwrap();
+
+    assert!(wrapper_node.has_class("wrapper"));
+    // The parent should still have two children (wrapper and second-child)
+    assert_eq!(doc.select("#parent > *").length(), 2);
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_unwrap_node() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let sel = doc.select("#first-child");
+    let node = sel.nodes().first().unwrap();
+    node.unwrap_node();
+
+    // The parent of #first-child (id="parent") should be removed
+    assert!(doc.select("#parent").is_empty());
+
+    // The grand-parent (id="grand-parent") should now directly contain #first-child
+    assert_eq!(doc.select("#grand-parent > #first-child").length(), 1);
+
+    // #second-child should also be removed with #parent
+    assert!(doc.select("#second-child").is_empty());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_unwrap_node_noop_if_no_parent() {
+    let doc = Document::from(ANCESTORS_CONTENTS);
+
+    let root = doc.root();
+    root.unwrap_node();
+
+    // Nothing should change, root cannot be unwrapped
+    assert_eq!(doc.select("html").length(), 1);
+    assert_eq!(doc.select("#great-ancestor").length(), 1);
+}


### PR DESCRIPTION
Adding `NodeRef::wrap_node()`, `NodeRef::wrap_html()`, and `NodeRef::unwrap_node()` utility functions. 

Brings feature parity with jQuery's wrap() and unwrap() methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to wrap a node with another node or an HTML fragment, and to unwrap a node from its parent in the DOM tree.

- **Tests**
  - Introduced new tests to verify node wrapping and unwrapping functionality, ensuring correct DOM restructuring and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->