### PR TITLE
chore: update changelog and fix template serialization in NodeRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to the `dom_query` crate will be documented in this file.
 - Improved `mini_selector::Attribute`: attribute values can now be enclosed in either double or single quotes, or left unquoted.
 - Changed `entities::Attr` visibility to `pub`.
 
+### Fixed
+- Fixed `template` serialization in `NodeRef::html` and `NodeRef::inner_html` methods.
+
 ## [0.17.0] - 2025-03-31
 
 ### Added

--- a/src/node/serializing.rs
+++ b/src/node/serializing.rs
@@ -93,17 +93,8 @@ mod tests {
 
     #[test]
     fn test_template_serialization() {
-        let doc = Document::from(
+        let contents=
             r#"<html>
-                <body>
-                    <template>
-                        <p>template content</p>
-                    </template>
-                </body>
-            </html>"#,
-        );
-        let got_html = doc.html();
-        let expected_html = r#"<html>
                 <head></head>
                 <body>
                     <template>
@@ -111,11 +102,13 @@ mod tests {
                     </template>
                 </body>
             </html>"#;
+        let doc = Document::from(contents);
+        let got_html = doc.html();
         assert_eq!(
-            got_html.split_ascii_whitespace().collect::<Vec<&str>>(),
-            expected_html
+            got_html.split_ascii_whitespace().collect::<Vec<&str>>().join(""),
+            contents
                 .split_ascii_whitespace()
-                .collect::<Vec<&str>>()
+                .collect::<Vec<&str>>().join("")
         );
     }
 }

--- a/src/node/serializing.rs
+++ b/src/node/serializing.rs
@@ -57,6 +57,10 @@ impl Serialize for SerializableNodeRef<'_> {
                                 child_nodes(Ref::clone(&nodes), &id, true).map(SerializeOp::Open),
                             );
 
+                            if let Some(tpl_doc_root) = e.template_contents {
+                                ops.push(SerializeOp::Open(tpl_doc_root));
+                            }
+
                             Ok(())
                         }
                         NodeData::Doctype { ref name, .. } => serializer.write_doctype(name),
@@ -80,5 +84,38 @@ impl Serialize for SerializableNodeRef<'_> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Document;
+
+    #[test]
+    fn test_template_serialization() {
+        let doc = Document::from(
+            r#"<html>
+                <body>
+                    <template>
+                        <p>template content</p>
+                    </template>
+                </body>
+            </html>"#,
+        );
+        let got_html = doc.html();
+        let expected_html = r#"<html>
+                <head></head>
+                <body>
+                    <template>
+                        <p>template content</p>
+                    </template>
+                </body>
+            </html>"#;
+        assert_eq!(
+            got_html.split_ascii_whitespace().collect::<Vec<&str>>(),
+            expected_html
+                .split_ascii_whitespace()
+                .collect::<Vec<&str>>()
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the contents of `<template>` elements were not included during HTML serialization.

- **Tests**
  - Added a test to ensure correct serialization of documents containing `<template>` elements.

- **Documentation**
  - Updated the changelog to document the serialization fix for `<template>` elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->