### PR TITLE
Adding test to isolate bug where the dom tree and the rendered html are not consistent

### DIFF
--- a/tests/html-dom.rs
+++ b/tests/html-dom.rs
@@ -169,6 +169,7 @@ fn doctype() {
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[ignore = "Known serialization bug – tracked in issue #96"]
 fn doc_render_bug() {
     const HTML: &str = r#"<!DOCTYPE html><html><head></head><body>
            <div id="parent">


### PR DESCRIPTION
There is a bug where what is present in the DOM (selectable via doc.select) is not represented in the html when doc is rendered. 

This PR adds the test to surface the bug, but does not attempt to resolve the bug. 

```
> cargo test doc_render_bug

running 1 test
test doc_render_bug ... FAILED

failures:

---- doc_render_bug stdout ----

thread 'doc_render_bug' panicked at tests/html-dom.rs:211:5:
assertion `left == right` failed: wrapper div is missing from document
  left: "<!DOCTYPE html><html><head></head><body>\n           <div id=\"parent\"><div id=\"child\" class=\"child\">Child</div>\n            </div>\n        </body></html>"
 right: "<!DOCTYPE html><html><head></head><body>\n           <div id=\"parent\">\n               <div id=\"wrapper\"><div id=\"child\" class=\"child\">Child</div></div>\n            </div>\n        </body></html>"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    doc_render_bug
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to check the correct rendering of dynamically inserted DOM elements in HTML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->