### PR TITLE
src/dom_tree/tree.rs: add `Tree::html_root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+## Added
+- Introduced `Tree::html_root` and `Document::html_root` methods to get the root element (`<html>`) node of a document.
+
 ## [0.18.0] - 2025-04-26
 
 ## Added

--- a/src/document.rs
+++ b/src/document.rs
@@ -90,6 +90,11 @@ impl Document {
         self.tree.root()
     }
 
+    /// Returns the root element node (`<html>`) of the document.
+    pub fn html_root(&self) -> NodeRef {
+        self.tree.html_root()
+    }
+
     /// Gets the HTML contents of the document. It includes
     /// the text and comment nodes.
     pub fn html(&self) -> StrTendril {

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -131,6 +131,17 @@ impl Tree {
         self.get_unchecked(&NodeId::new(0))
     }
 
+    /// Gets the element root node.
+    /// 
+    /// Even if [crate::Document] was constructed with an empty string, 
+    /// it will still have a root element node (`<html>`).
+    /// 
+    /// # Returns
+    /// - `NodeRef`: The root element (`<html>``) node.
+    pub fn html_root(&self) -> NodeRef {
+        self.root().first_element_child().expect("expecting 'html' element")
+    }
+
     /// Gets the ancestors nodes of a node by id.
     ///
     /// # Arguments

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -517,3 +517,45 @@ fn test_doc_format_md_table() {
     | 4 | 5 | 6 |";
     assert_eq!(text.as_ref(), expected);
 }
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_html_root() {
+    let doc = Document::from(MINI_TABLE_CONTENTS);
+    let html_node = doc.html_root();
+    assert!(html_node.has_name("html"));
+
+    let empty_doc = Document::from("");
+    let html_node = empty_doc.html_root();
+    assert!(html_node.has_name("html"));
+
+    let fragment = Document::fragment(MINI_TABLE_CONTENTS);
+    let html_node = fragment.html_root();
+    assert!(html_node.has_name("html"));
+
+    let empty_fragment = Document::fragment("");
+    let html_node = empty_fragment.html_root();
+    assert!(html_node.has_name("html"));
+
+    let bad_contents = "<something-bad";
+
+    let bad_doc = Document::from(bad_contents);
+    let html_node = bad_doc.html_root();
+    assert!(html_node.has_name("html"));
+
+    let bad_fragment = Document::fragment(bad_contents);
+    let html_node = bad_fragment.html_root();
+    assert!(html_node.has_name("html"));
+
+    let contents_wo_html = "<div></div>";
+
+    let doc = Document::from(contents_wo_html);
+    let html_node = doc.html_root();
+    assert!(html_node.has_name("html"));
+
+    let fragment = Document::fragment(contents_wo_html);
+    let html_node = fragment.html_root();
+    assert!(html_node.has_name("html"));
+
+
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a method to easily retrieve the root `<html>` element of a document.

- **Tests**
  - Added tests to verify that the new method consistently returns the `<html>` element, regardless of document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->