### PR TITLE
src/node/node_ref.rs: fix `NodeRef::to_fragment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Fixed
 
-- Fixed the behavior of `NodeRef::to_fragment` when the node is an html element or the root itself.
+- Fixed the behavior of `NodeRef::to_fragment` when the node is an `<html>` element or the root itself.
 
 ## [0.19.0] - 2025-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `dom_query` crate will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the behavior of `NodeRef::to_fragment` when the node is an html element or the root itself.
+
 ## [0.19.0] - 2025-05-20
 
 ### Added

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -747,7 +747,6 @@ impl NodeRef<'_> {
 
     /// Creates a full copy of the node's contents as a [Document] fragment.
     pub fn to_fragment(&self) -> Document {
-
         if self.id.value == 0 || self.has_name("html") {
             return Document {
                 tree: self.tree.clone(),

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -747,23 +747,30 @@ impl NodeRef<'_> {
 
     /// Creates a full copy of the node's contents as a [Document] fragment.
     pub fn to_fragment(&self) -> Document {
-        let fragment = Document::fragment_sink();
 
-        let fragment_root_id = fragment.tree.root().id;
-        fragment.tree.new_element("body");
+        if self.id.value == 0 || self.has_name("html") {
+            return Document {
+                tree: self.tree.clone(),
+                ..Default::default()
+            };
+        }
 
-        let html_node = fragment.tree.new_element("html");
-        fragment
-            .tree
-            .append_child_of(&fragment_root_id, &html_node.id);
+        let frag = Document::fragment_sink();
+        let f_tree = &frag.tree;
+        let f_root_id = f_tree.root().id;
+
+        f_tree.new_element("body");
+
+        let html_node = f_tree.new_element("html");
+        f_tree.append_child_of(&f_root_id, &html_node.id);
 
         {
-            let new_child_id = fragment.tree.copy_node(self);
-            let mut fragment_nodes = fragment.tree.nodes.borrow_mut();
+            let new_child_id = f_tree.copy_node(self);
+            let mut fragment_nodes = f_tree.nodes.borrow_mut();
             TreeNodeOps::append_children_of(&mut fragment_nodes, &html_node.id, &new_child_id);
         }
 
-        fragment
+        frag
     }
 }
 

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -579,5 +579,12 @@ fn test_copy_fragment() {
         dst_node.children_it(false).count()
     );
 
+    let frag = src_frag.root().to_fragment();
+    assert_eq!(frag.select("html").length(), 1);
+
+    let frag = src_frag.html_root().to_fragment();
+    assert_eq!(frag.select("html").length(), 1);
+
+
     assert!(dst_frag.tree.validate().is_ok());
 }

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -585,6 +585,5 @@ fn test_copy_fragment() {
     let frag = src_frag.html_root().to_fragment();
     assert_eq!(frag.select("html").length(), 1);
 
-
     assert!(dst_frag.tree.validate().is_ok());
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of fragment conversion for root and HTML nodes to ensure correct document structure.

- **Tests**
  - Added new test assertions to verify that fragment conversion preserves a single "html" element in the resulting document.

- **Documentation**
  - Updated the changelog to document the fix related to fragment conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->