### PR TITLE
examples/manipulate_html.rs: assert that doc.select(".remove-it").exists() is false

### DIFF
--- a/examples/manipulate_html.rs
+++ b/examples/manipulate_html.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Remove selection from the document
     doc.select(".remove-it").remove();
-    assert!(doc.select(".remove-it").exists());
+    assert_eq!(doc.select(".remove-it").exists(), false);
 
     // Replacing inner block content with new content, current selection remains the same
     let replace_selection = doc.select(".replace-it");


### PR DESCRIPTION
When I ran the example file manipulate_html.rs, I got this error:

```
thread 'main' panicked at examples/manipulate_html.rs:39:5:
assertion failed: doc.select(".remove-it").exists()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Looking at the code in https://github.com/niklak/dom_query/blob/6f0d9cd37e4817e5afd7b96e35689d3a88ae7a34/examples/manipulate_html.rs#L39, the element is removed from the DOM, so it should assert that it doesn't exist, correct?

