### PR TITLE
implement `Copy` trait for `NodeRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Introduced the Selection::select_matcher_iter method, which returns an iterator over all nodes matching the given matcher, without collecting them into a result vector. Useful for read-only operations
+- Introduced the `Selection::select_matcher_iter` method, which returns an iterator over all nodes matching the given matcher, without collecting them into a result vector. Useful for read-only operations.
 
 
 ### Changed
+- `NodeRef` implements `Copy` trait.
 - Minor code refactoring.
 
 ## [0.19.2] - 2025-07-08

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -394,7 +394,7 @@ impl Tree {
         let mut id_map: InnerHashMap<usize, usize> = InnerHashMap::default();
         id_map.insert(node.id.value, next_id_val);
 
-        let mut ops = vec![node.clone()];
+        let mut ops = vec![*node];
 
         while let Some(op) = ops.pop() {
             for child in op.children_it(false) {

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -29,7 +29,7 @@ use super::NodeId;
 
 pub type Node<'a> = NodeRef<'a>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 /// Represents a reference to a node in the tree.
 /// It keeps a node id and a reference to the tree,
 /// which allows to access to the actual tree node with [NodeData].
@@ -581,7 +581,7 @@ impl NodeRef<'_> {
     }
 
     fn serialize_html(&self, traversal_scope: TraversalScope) -> Option<StrTendril> {
-        let inner: SerializableNodeRef = self.clone().into();
+        let inner: SerializableNodeRef = (*self).into();
         let mut result = vec![];
         serialize(
             &mut result,

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -584,7 +584,7 @@ impl<'a> Selection<'a> {
             return Selection::default();
         }
         let nodes = if self.nodes().len() == 1 {
-            let root_node = self.nodes()[0].clone();
+            let root_node = self.nodes()[0];
             DescendantMatches::new(root_node, matcher).collect()
         } else {
             Matches::new(self.nodes.clone().into_iter().rev(), matcher).collect()
@@ -626,7 +626,7 @@ impl<'a> Selection<'a> {
             return Selection::default();
         }
         let node = if self.nodes().len() == 1 {
-            DescendantMatches::new(self.nodes()[0].clone(), matcher).next()
+            DescendantMatches::new(self.nodes()[0], matcher).next()
         } else {
             Matches::new(self.nodes.clone().into_iter().rev(), matcher).next()
         };
@@ -769,7 +769,7 @@ impl<'a> Selection<'a> {
     /// selection is empty.
     pub fn first(&self) -> Selection<'a> {
         if self.length() > 0 {
-            Selection::from(self.nodes[0].clone())
+            Selection::from(self.nodes[0])
         } else {
             Default::default()
         }
@@ -780,7 +780,7 @@ impl<'a> Selection<'a> {
     /// selection is empty.
     pub fn last(&self) -> Selection<'a> {
         if self.length() > 0 {
-            Selection::from(self.nodes[self.length() - 1].clone())
+            Selection::from(self.nodes[self.length() - 1])
         } else {
             Default::default()
         }
@@ -875,7 +875,7 @@ impl <'a>Selection<'a> {
         match self.nodes().len() {
             0 => Box::new(std::iter::empty()),
             1 => {
-                let root_node = self.nodes()[0].clone();
+                let root_node = self.nodes()[0];
                 Box::new(DescendantMatches::new(root_node, matcher))
             }
             _ => Box::new(Matches::new(

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -262,13 +262,13 @@ fn test_node_prev_sibling() {
     let last_child = last_child_sel.nodes().first().unwrap();
 
     let prev_sibling = last_child.prev_sibling().unwrap();
-    let prev_sibling_sel = Selection::from(prev_sibling.clone());
+    let prev_sibling_sel = Selection::from(prev_sibling);
     // in this case prev element is not an element but a text node with whitespace (indentation)
     assert!(!prev_sibling_sel.is("#first-child"));
 
     // so, more convenient way to get previous element sibling is:
     let prev_element_sibling = last_child.prev_element_sibling().unwrap();
-    let prev_element_sibling_sel = Selection::from(prev_element_sibling.clone());
+    let prev_element_sibling_sel = Selection::from(prev_element_sibling);
     assert!(prev_element_sibling_sel.is("#first-child"));
 }
 

--- a/tests/selection-query.rs
+++ b/tests/selection-query.rs
@@ -154,7 +154,7 @@ fn test_is_has() {
     let anchor_node = sel.nodes().first().unwrap();
 
     let prev_sibling = anchor_node.prev_element_sibling().unwrap();
-    let prev_sel = Selection::from(prev_sibling.clone());
+    let prev_sel = Selection::from(prev_sibling);
 
     assert!(prev_sel.is("*:has( > img:only-child)"));
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `NodeRef` type now supports copy operations for improved performance and convenience.

* **Refactor**
  * Reduced unnecessary cloning of nodes throughout selection and traversal methods, leading to more efficient code execution.

* **Documentation**
  * Updated changelog to reflect recent changes and correct formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->