### PR TITLE
Fix/document create template element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Fixed `TreeNodeOps::merge_with_fn` to correctly handle cases where the first visible child of the other tree is a `<template>` element. In that case, the attaching node was a Document (incorrectly) instead of the `<template>` itself. After the fix, the attaching node is correctly the `<template>`.
+- Revised `Document::create_element`. Now the template element precedes its `Fragment`, allowing HTML trees with templates to be merged more predictably.
 - Skip merging trees (and all related operations) when the main tree is empty (e.g., a document created via `Document::default()`).
 
 ### Changed

--- a/src/dom_tree/ops.rs
+++ b/src/dom_tree/ops.rs
@@ -479,18 +479,11 @@ impl TreeNodeOps {
     where
         F: FnOnce(&mut Vec<TreeNode>, NodeId),
     {
-        let mut anchor = nodes.len();
+        let anchor = nodes.len();
         if anchor < SKIP_NODES_ON_MERGE {
             return;
         }
         let other_nodes = other.nodes.into_inner();
-        if let Some(first_node) = other_nodes.get(SKIP_NODES_ON_MERGE) {
-            // If `<template>` starts an html fragment,
-            // then the first node will be actually a `NodeData::Document`, which we need to skip.
-            if first_node.is_document() && other_nodes.len() > SKIP_NODES_ON_MERGE + 1 {
-                anchor += 1;
-            }
-        }
         Self::merge(nodes, other_nodes);
         let new_node_id = NodeId::new(anchor);
         f(nodes, new_node_id);

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -375,7 +375,7 @@ impl Tree {
     ///
     /// # Arguments
     ///
-    /// * `node` - reference to a node in the other tree
+    /// * `node` - reference to a node in the source tree (may be the same tree)
     ///
     /// # Returns
     ///
@@ -439,8 +439,9 @@ impl Tree {
         new_nodes
     }
 
-    /// Copies nodes from another tree to the current tree and applies the given function
-    /// to each copied node. The function is called with the ID of each copied node.
+    /// Copies each node from `other_nodes` (and its subtree) to the current tree and
+    /// applies the given function once per top-level copied node. The function is called
+    /// with the ID of each top-level copied node (not each descendant).
     ///
     /// # Arguments
     ///

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -371,11 +371,15 @@ impl Tree {
         NodeId::new(self.nodes.borrow().len())
     }
 
-    ///Adds a copy of the node and its children to the current tree
+    ///Adds a copy of the node and its children to the current tree.
+    /// 
+    /// Note: For `<template>` elements, the associated `template_contents` fragment (if any)
+    /// is also copied and its IDs remapped to the destination tree.
     ///
     /// # Arguments
     ///
     /// * `node` - reference to a node in the source tree (may be the same tree)
+    /// 
     ///
     /// # Returns
     ///
@@ -447,9 +451,9 @@ impl Tree {
     ///
     /// * `other_nodes` - slice of nodes to be copied
     /// * `f` - function to be applied to each copied node
-    pub(crate) fn copy_nodes_with_fn<F>(&self, other_nodes: &[NodeRef], f: F)
+    pub(crate) fn copy_nodes_with_fn<F>(&self, other_nodes: &[NodeRef], mut f: F)
     where
-        F: Fn(NodeId),
+        F: FnMut(NodeId),
     {
         // copying each other node into the current tree, and applying the function
         for other_node in other_nodes {

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -414,7 +414,7 @@ impl Tree {
     }
 
     fn copy_tree_nodes(source_tree: &Tree, id_map: &InnerHashMap<usize, usize>) -> Vec<TreeNode> {
-        let mut new_nodes: Vec<TreeNode> = vec![];
+        let mut new_nodes: Vec<TreeNode> = Vec::with_capacity(id_map.len());
         let source_nodes = source_tree.nodes.borrow();
         let adjust_id = |old_id: NodeId| id_map.get(&old_id.value).map(|id| NodeId::new(*id));
         let tree_nodes_it = id_map.iter().flat_map(|(old_id, new_id)| {

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -1,9 +1,12 @@
 mod data;
-
 use data::{
     doc_with_siblings, ATTRS_CONTENTS, EMPTY_BLOCKS_CONTENTS, REPLACEMENT_CONTENTS,
     REPLACEMENT_SEL_CONTENTS,
 };
+
+mod utils;
+use utils::squash_whitespace;
+
 use dom_query::Document;
 
 #[cfg(target_arch = "wasm32")]
@@ -225,6 +228,24 @@ fn test_append_another_tree_selection() {
     sel_dst.append_selection(&sel_src);
     assert_eq!(doc_dst.select(".ad-content .source").length(), 4);
     assert_eq!(doc_dst.select(".ad-content span").length(), 6);
+
+    doc_dst.tree.validate().unwrap();
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_append_template_another_tree_selection() {
+    let doc_dst = Document::from(REPLACEMENT_SEL_CONTENTS);
+
+    let contents_src = r#"<div class="source"><template><p>inner text</p></template></div>"#;
+
+    let doc_src = Document::from(contents_src);
+
+    let sel_dst = doc_dst.select("body");
+    let sel_src = doc_src.select("div.source");
+
+    sel_dst.append_selection(&sel_src);
+    assert!(doc_dst.html().contains(contents_src));
 
     doc_dst.tree.validate().unwrap();
 }
@@ -471,17 +492,9 @@ fn test_select_inject_empty_template() {
             <script></script>
         </body>
     </html>
-    "#
-    .split_whitespace()
-    .collect::<Vec<&str>>()
-    .join("");
+    "#;
 
-    let got = doc
-        .html()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .join("");
-    assert_eq!(expected, got);
+    assert_eq!(squash_whitespace(expected), squash_whitespace(&doc.html()));
 
     // Ensure internal links are sound when templates are injected.
     doc.tree.validate().unwrap();
@@ -521,17 +534,9 @@ fn test_select_inject_template() {
         <p>after</p>
         </body>
     </html>
-    "#
-    .split_whitespace()
-    .collect::<Vec<&str>>()
-    .join("");
+    "#;
 
-    let got = doc
-        .html()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .join("");
-    assert_eq!(expected, got);
+    assert_eq!(squash_whitespace(expected), squash_whitespace(&doc.html()));
 
     // Ensure internal links are sound when templates are injected.
     doc.tree.validate().unwrap();

--- a/tests/selection-manipulation.rs
+++ b/tests/selection-manipulation.rs
@@ -245,7 +245,9 @@ fn test_append_template_another_tree_selection() {
     let sel_src = doc_src.select("div.source");
 
     sel_dst.append_selection(&sel_src);
-    assert!(doc_dst.html().contains(contents_src));
+    assert!(
+        squash_whitespace(&doc_dst.html()).contains(&squash_whitespace(contents_src))
+    );
 
     doc_dst.tree.validate().unwrap();
 }

--- a/tests/selection-property.rs
+++ b/tests/selection-property.rs
@@ -11,6 +11,9 @@ use wasm_bindgen_test::*;
 
 mod alloc;
 
+mod utils;
+use utils::squash_whitespace;
+
 #[cfg_attr(not(target_arch = "wasm32"), test)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn test_attr_exists() {
@@ -290,25 +293,16 @@ fn test_doc_try_serialize_html() {
     let inner_html = doc.try_inner_html();
     assert!(inner_html.is_some());
     // because of whitespace serialization serialized content will be different from the original content.
-    let got_html = html
-        .unwrap()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("");
-    let expected = ANCESTORS_CONTENTS
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("");
-    assert_eq!(got_html, expected);
+    let got_html = squash_whitespace(&html.unwrap());
+    let expected = squash_whitespace(ANCESTORS_CONTENTS);
+    assert_eq!(expected, got_html);
+
+
 
     // Calling `try_inner_html` and `try_html` on `Document` will produce the same result.
     // The same thing applies to the `inner_html` and `html` methods.
-    let got_inner_html = inner_html
-        .unwrap()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("");
-    assert_eq!(got_inner_html, expected);
+    let got_inner_html = squash_whitespace(&inner_html.unwrap());
+    assert_eq!(expected, got_inner_html);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -320,17 +314,14 @@ fn test_doc_serialize_html() {
 
     let inner_html = doc.inner_html();
     // because of whitespace serialization serialized content will be different from the original content.
-    let got_html = html.split_whitespace().collect::<Vec<_>>().join("");
-    let expected = ANCESTORS_CONTENTS
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join("");
-    assert_eq!(got_html, expected);
+    let got_html = squash_whitespace(&html);
+    let expected = squash_whitespace(ANCESTORS_CONTENTS);
+    assert_eq!(expected, got_html);
 
     // Calling `try_inner_html` and `try_html` on `Document` will produce the same result.
     // The same thing applies to the `inner_html` and `html` methods.
-    let got_inner_html = inner_html.split_whitespace().collect::<Vec<_>>().join("");
-    assert_eq!(got_inner_html, expected);
+    let got_inner_html = squash_whitespace(&inner_html);
+    assert_eq!(expected, got_inner_html);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -342,7 +333,7 @@ fn test_doc_text() {
     let text = doc.text().split_whitespace().collect::<Vec<_>>().join(" ");
     // The result includes html > head > title, just like goquery does.
     // Therefore, it must contain the text from the title and the texts from the two blocks.
-    assert_eq!(text, "Test Child Child");
+    assert_eq!("Test Child Child", text);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -3,6 +3,5 @@
 pub (crate) fn squash_whitespace(src: &str) -> String {
     src
         .split_whitespace()
-        .collect::<Vec<&str>>()
-        .join("")
+        .collect::<String>()
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+pub (crate) fn squash_whitespace(src: &str) -> String {
+    src
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join("")
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More predictable merging of HTML trees containing template elements.
  * Preserves template contents when moving elements between different trees.

* **Refactor**
  * Internal creation and representation of template elements and their fragments simplified for more consistent behavior.

* **Documentation**
  * Clarified description for the copy operation parameter.

* **Tests**
  * Added a whitespace-normalizing test utility and standardized HTML assertions.
  * Added a test verifying template contents persist when appended across trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->