### PR TITLE
 add body and head methods to Document and Tree

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install stable rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.83.0
+        toolchain: 1.89.0
         targets: wasm32-unknown-unknown
     - name: Install wasm-bindgen-cli
       uses: taiki-e/install-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Introduced `Tree::body` and `Document::body` methods.
-- Introduced `Tree::head` and `Document::head` methods.
+- Introduced `Tree::head` and `Tree::body` methods. Both return `None` if the corresponding element is absent (e.g., fragments usually
+ don’t contain `<body>`/`<head>`). `Document::head` and `Document::body` methods return the same as `Tree::head` and `Tree::body` methods, respectively.
 
 ### Fixed
 - Revised `Document::create_element`. Now the template element precedes its `Fragment`, allowing HTML trees with templates to be merged more predictably.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- Introduced `Tree::head` and `Tree::body` methods. Both return `None` if the corresponding element is absent (e.g., fragments usually
- don’t contain `<body>`/`<head>`). `Document::head` and `Document::body` methods return the same as `Tree::head` and `Tree::body` methods, respectively.
+ - Introduced `Tree::head` and `Tree::body` methods, which return `None` if the corresponding element is absent (e.g., fragments typically lack `<head>`/`<body>`). Added equivalent `Document::head` and `Document::body` methods.
 
 ### Fixed
 - Revised `Document::create_element`. Now the template element precedes its `Fragment`, allowing HTML trees with templates to be merged more predictably.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ## [Unreleased]
 
 ### Added
- - Introduced `Tree::head` and `Tree::body` methods, which return `None` if the corresponding element is absent (e.g., fragments typically lack `<head>`/`<body>`). Added equivalent `Document::head` and `Document::body` methods.
+- Introduced `Tree::head` and `Tree::body` methods, which return `None` if the corresponding element is absent (e.g., fragments typically lack `<head>`/`<body>`). Added equivalent `Document::head` and `Document::body` methods.
 
 ### Fixed
 - Revised `Document::create_element`. Now the template element precedes its `Fragment`, allowing HTML trees with templates to be merged more predictably.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Introduced `Tree::body` and `Document::body` methods.
+- Introduced `Tree::head` and `Document::head` methods.
+
 ### Fixed
 - Revised `Document::create_element`. Now the template element precedes its `Fragment`, allowing HTML trees with templates to be merged more predictably.
 - Skip merging trees (and all related operations) when the main tree is empty (e.g., a document created via `Document::default()`).

--- a/src/document.rs
+++ b/src/document.rs
@@ -149,14 +149,19 @@ impl Document {
         self.tree.base_uri()
     }
 
-    /// Returns the document's body element, if it exists.
+    /// Returns the document's `<body>` element, or `None` if absent.
+    /// For fragments ([crate::NodeData::Fragment]), this typically returns `None`.
     pub fn body(&self) -> Option<NodeRef<'_>> {
         self.tree.body()
     }
-    /// Returns the document's head element, if it exists.
+
+    /// Returns the document's `<head>` element, or `None` if absent.
+    /// For fragments ([crate::NodeData::Fragment]), this typically returns `None`.
     pub fn head(&self) -> Option<NodeRef<'_>> {
         self.tree.head()
     }
+
+
 
     /// Merges adjacent text nodes and removes empty text nodes.
     ///

--- a/src/document.rs
+++ b/src/document.rs
@@ -149,6 +149,15 @@ impl Document {
         self.tree.base_uri()
     }
 
+    /// Returns the document's body element, if it exists.
+    pub fn body(&self) -> Option<NodeRef<'_>> {
+        self.tree.body()
+    }
+    /// Returns the document's head element, if it exists.
+    pub fn head(&self) -> Option<NodeRef<'_>> {
+        self.tree.head()
+    }
+
     /// Merges adjacent text nodes and removes empty text nodes.
     ///
     /// Normalization is necessary to ensure that adjacent text nodes are merged into one text node.

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -90,6 +90,7 @@ impl Tree {
 
 
     /// Finds the `<body>` node element in the tree.
+    /// For fragments ([crate::NodeData::Fragment]), this typically returns `None`.
     pub fn body(&self) -> Option<NodeRef<'_>> {
         let root = self.root();
         Traversal::find_descendant_element(self.nodes.borrow(), root.id, &["html", "body"])
@@ -97,10 +98,11 @@ impl Tree {
     }
 
     /// Finds the `<head>` node element in the tree.
+    /// For fragments ([crate::NodeData::Fragment]), this typically returns `None`.
     pub fn head(&self) -> Option<NodeRef<'_>> {
         let root = self.root();
         Traversal::find_descendant_element(self.nodes.borrow(), root.id, &["html", "head"])
-            .map(|body_id| NodeRef::new(body_id, self))
+            .map(|head_id| NodeRef::new(head_id, self))
     }
 
 

--- a/src/dom_tree/tree.rs
+++ b/src/dom_tree/tree.rs
@@ -87,6 +87,23 @@ impl Tree {
             .and_then(|base_node_id| nodes.get(base_node_id.value))
             .and_then(|base_node| base_node.as_element()?.attr("href"))
     }
+
+
+    /// Finds the `<body>` node element in the tree.
+    pub fn body(&self) -> Option<NodeRef<'_>> {
+        let root = self.root();
+        Traversal::find_descendant_element(self.nodes.borrow(), root.id, &["html", "body"])
+            .map(|body_id| NodeRef::new(body_id, self))
+    }
+
+    /// Finds the `<head>` node element in the tree.
+    pub fn head(&self) -> Option<NodeRef<'_>> {
+        let root = self.root();
+        Traversal::find_descendant_element(self.nodes.borrow(), root.id, &["html", "head"])
+            .map(|body_id| NodeRef::new(body_id, self))
+    }
+
+
 }
 
 impl Tree {

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -605,7 +605,7 @@ fn test_node_body() {
     let body = doc.body().unwrap();
     assert!(body.is("body"));
     
-    // htm5ever will create html and body elements, even if source content is empty.
+    // html5ever will create html and body elements, even if source content is empty.
     let doc = Document::from("");
     assert!(doc.body().is_some());
 
@@ -643,7 +643,7 @@ fn test_node_head() {
     let body = doc.head().unwrap();
     assert!(body.is("head:has(title)"));
     
-    // htm5ever will create html and head elements, even if source content is empty.
+    // html5ever will create html and head elements, even if source content is empty.
     let doc = Document::from("");
     assert!(doc.head().is_some());
 

--- a/tests/node-traversal.rs
+++ b/tests/node-traversal.rs
@@ -587,3 +587,73 @@ fn test_copy_fragment() {
 
     assert!(dst_frag.tree.validate().is_ok());
 }
+
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_body() {
+    let contents: &str = 
+    r#"
+    <html>
+        <body>
+            <div class="bg-dark"><p>Paragraph</p></div>
+        </body>
+    </html>"#;
+    let doc = Document::from(contents);
+
+    // It may be called from document level.
+    let body = doc.body().unwrap();
+    assert!(body.is("body"));
+    
+    // htm5ever will create html and body elements, even if source content is empty.
+    let doc = Document::from("");
+    assert!(doc.body().is_some());
+
+
+    let frag_contents: &str =
+    r#"<div class="bg-dark"><p>Paragraph</p></div>"#;
+    // fragment will not create a body element.
+    let fragment = Document::fragment(frag_contents);
+    assert!(fragment.body().is_none());
+
+    let frag_contents: &str =
+    r#"<html><body class="bg-dark"><p>Paragraph</p></body></html>"#;
+    // fragment ignores `body` and puts its content directly into `html`.
+    let fragment = Document::fragment(frag_contents);
+    assert!(fragment.body().is_none());
+    assert!(fragment.select("html > p").exists());
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+fn test_node_head() {
+    let contents: &str = 
+    r#"
+    <html>
+        <head>
+            <title>Test Document</title>
+            <meta charset="UTF-8">
+        </head>
+        <body>
+        </body>
+    </html>"#;
+    let doc = Document::from(contents);
+
+    // It may be called from document level.
+    let body = doc.head().unwrap();
+    assert!(body.is("head:has(title)"));
+    
+    // htm5ever will create html and head elements, even if source content is empty.
+    let doc = Document::from("");
+    assert!(doc.head().is_some());
+
+
+    let frag_contents: &str =
+    r#"<html><head>
+            <title>Test Document</title>
+        </head></html>"#;
+    // fragment will not create a head element.
+    let fragment = Document::fragment(frag_contents);
+    assert!(fragment.head().is_none());
+    assert!(fragment.select("html > title").exists());
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added easy accessors to retrieve an HTML document’s head and body sections.
* Bug Fixes
  * Template elements now merge more predictably with surrounding content.
  * Merging is skipped when the main document is empty to avoid unnecessary work and edge cases.
* Tests
  * Added tests covering head/body detection and behavior in documents vs. fragments.
* Documentation
  * Updated changelog with these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->