### PR TITLE
Adjust last new line in `<pre>` code block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,4 +39,4 @@ pub use node::{Element, Node, NodeData, NodeId, NodeIdProver, NodeRef};
 pub use selection::Selection;
 
 // re-export
-pub use html5ever::{LocalName, local_name};
+pub use html5ever::{local_name, LocalName};

--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -258,7 +258,10 @@ impl<'a> MDSerializer<'a> {
     fn write_pre(&self, text: &mut StrTendril, pre_node: &TreeNode) {
         text.push_slice("\n```\n");
         text.push_tendril(&TreeNodeOps::text_of(Ref::clone(&self.nodes), pre_node.id));
-        text.push_slice("\n```\n");
+        if !text.ends_with('\n') {
+            text.push_char('\n');
+        }
+        text.push_slice("```\n");
     }
 
     fn write_code(&self, text: &mut StrTendril, code_node: &TreeNode) {
@@ -777,8 +780,22 @@ mod tests {
         let simple_contents = "<pre>\
 <span>fn</span> <span>main</span><span>()</span><span> </span><span>{</span>\n\
 <span>    </span><span>println!</span><span>(</span><span>\"Hello, World!\"</span><span>);</span>\n\
-<span>}</span>\
+<span>}</span>
 </pre>";
+        let simple_expected = "```
+fn main() {
+    println!(\"Hello, World!\");
+}
+```";
+        html_2md_compare(simple_contents, simple_expected);
+    }
+
+    #[test]
+    fn test_pre_code_without_new_line() {
+        let simple_contents = r#"<pre>
+<span>fn</span> <span>main</span><span>()</span><span> </span><span>{</span>
+<span>    </span><span>println!</span><span>(</span><span>"Hello, World!"</span><span>);</span>
+<span>}</span></pre>"#;
         let simple_expected = "```
 fn main() {
     println!(\"Hello, World!\");


### PR DESCRIPTION
This PR updates the generation of the Markdown code block, prior to this change the produced code block would contain an extra new line depending on the location of the closing `</pre>` tag. Given the following example:

```html
<pre>
fn main() {
    println!("Hello World");
}
</pre>
```

the outcome looks then:

````markdown
```
fn main() {
    println!("Hello World");
}

```
````

which contains an extra new line.

With the change the `write_pre` function only adds a new line when the text does not end on one to provide a consistent outcome without an addtional new line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown preformatted block output so closing code fences always start on a new line (correct handling when block content lacks a trailing newline).

* **Tests**
  * Updated expectations and added coverage for preformatted block cases without a trailing newline to validate the corrected formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->