### PR TITLE
Feature: annotate codeblock with language found in custom data attribute

### DIFF
--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -1,7 +1,5 @@
 use std::fmt::Debug;
 
-use tendril::StrTendril;
-
 use super::node_data::{Element, NodeData};
 use crate::NodeId;
 
@@ -87,14 +85,6 @@ impl TreeNode {
             self.data,
             NodeData::Document | NodeData::Fragment | NodeData::Element(_)
         )
-    }
-
-    /// Returns a reference to the underlying text if the node is text, otherwise `None` is returned.
-    pub fn as_text(&self) -> Option<&StrTendril> {
-        match self.data {
-            NodeData::Text { ref contents } => Some(contents),
-            _ => None,
-        }
     }
 
     /// Returns a reference to the node as an element. If the node is not an element, `None` is returned.


### PR DESCRIPTION
In case a given code block is declaring the language via an associated data attribute, e.g. `data-lang`, on either the `<pre>` tag itself or its direct parent tag, the updated `write_pre` function will attach the found label in the resulting Markdown code block as well.

For example:

```html
<pre data-lang="rust">
fn main() {
    println!("Hello, World");
}
</pre>
```

will result in:

````markdown
```rust
fn main() {
    println!("Hello, World");
}
```
````

Additionally the parent tag is checked as well, as unfortunately some `<pre>` & multiline `<code>` blocks won't specify the language attribute directly.

This can be easily extended to cover additional heuristics, for example checking if the list of CSS classes contains a known label, e.g. "rust", "javascript".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Markdown export now renders multiline code as fenced blocks and includes language hints when provided via data attributes (including inheriting from a parent element).
  - Added a public API to access a node as an element when applicable.
- Documentation
  - Expanded docs for code block rendering and language detection behavior.
- Tests
  - Added tests for multiline code rendering and language hint detection from elements and parents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->