### PR TITLE
linebreak adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Added
 - Implemented `Element::attr_ref` method which returns an `&str` reference to the attribute value by `html5ever::LocalName`.
 - Re-exported `html5ever::LocalName` and `html5ever::local_name`.
+- **Markdown**: Enhanced `<pre>`-block parsing by checking its associated `data-lang` attribute (by @justahero)
+- **Markdown**: Multiline `<code>` blocks are now parsed as `<pre>` blocks (by @justahero).
 ### Changed
 - Revised `NodeRef::find_descendants` (requires `mini_selector` feature). This method now supports `Adjacent (+)` and `Sibling (~)` combinators.
 
 ### Fixed
-- markdown: fixed block element linebreak handling.
+- **Markdown**: fixed block element linebreak handling.
 
 ## [0.22.0] - 2025-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the `dom_query` crate will be documented in this file.
 ### Added
 - Implemented `Element::attr_ref` method which returns an `&str` reference to the attribute value by `html5ever::LocalName`.
 - Re-exported `html5ever::LocalName` and `html5ever::local_name`.
-- **Markdown**: Enhanced `<pre>`-block parsing by checking its associated `data-lang` attribute (by @justahero)
+- **Markdown**: Enhanced `<pre>`-block parsing by checking its associated `data-lang` and `data-language` attributes (by @justahero)
 - **Markdown**: Multiline `<code>` blocks are now parsed as `<pre>` blocks (by @justahero).
 ### Changed
 - Revised `NodeRef::find_descendants` (requires `mini_selector` feature). This method now supports `Adjacent (+)` and `Sibling (~)` combinators.

--- a/Examples.md
+++ b/Examples.md
@@ -792,7 +792,7 @@ assert_eq!(found_count, total_links);
     <p>I really like using Markdown.</p>\
     <p>I think I'll use it to format all of my documents from now on.</p>";
 
-    let expected = "p \\{color: blue;\\}\n\
+    let expected = "p \\{color: blue;\\}\n\n\
     I really like using Markdown\\.\n\n\
     I think I'll use it to format all of my documents from now on\\.";
 

--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -289,7 +289,7 @@ impl<'a> MDSerializer<'a> {
     /// Transforms a `<pre>` code block, possibly with an associated language label that the resulting
     /// block is annotated with.
     fn write_pre(&self, text: &mut StrTendril, pre_node: &TreeNode) {
-        text.push_slice(&format!("\n```"));
+        text.push_slice("\n```");
         if let Some(lang) = self.find_code_language(pre_node) {
             text.push_slice(&lang);
         }

--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -282,7 +282,7 @@ impl<'a> MDSerializer<'a> {
             return Some(language);
         }
 
-        ancestor_nodes(Ref::clone(&self.nodes), &node.id, Some(1))
+        ancestor_nodes(Ref::clone(&self.nodes), &node.id, Some(3))
             .find_map(|id| find_code_lang_attribute(&self.nodes[id.value]))
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Fenced code blocks now include language labels when data-lang/data-language attributes are present.
  * Multiline inline code is automatically converted to fenced code blocks for correct formatting.

* Bug Fixes
  * Improved Markdown line-break handling: horizontal rules enforce double line breaks; line breaks render via two spaces + newline.
  * Trailing spaces trimmed before inserting Markdown line breaks to avoid artifacts.

* Documentation
  * Updated examples to reflect added blank line after style blocks.
  * Changelog formatting adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->