### PR TITLE
Detect code language in CSS style with pattern

### DIFF
--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -3,7 +3,6 @@ use std::cell::Ref;
 use html5ever::{local_name, QualName};
 use tendril::StrTendril;
 
-use crate::dom_tree::Traversal;
 use crate::{Element, NodeId, TreeNodeOps};
 
 use crate::node::{ancestor_nodes, child_nodes, descendant_nodes, NodeData, NodeRef};
@@ -288,11 +287,14 @@ impl<'a> MDSerializer<'a> {
     /// Tries to find the language from the CSS class of the `<code>` block, which needs to be single child
     /// of the `<pre>` block.
     fn find_code_css_class_language(&self, pre_node: &TreeNode) -> Option<String> {
-        let code_node_id =
-            Traversal::find_child_element_by_name(Ref::clone(&self.nodes), pre_node.id, "code")?;
-        let code_node = &self.nodes[code_node_id.value];
+        let children = child_nodes(Ref::clone(&self.nodes), &pre_node.id, false);
+        if children.count() == 1 {
+            let code_node_id = pre_node.first_child?;
+            let code_node = &self.nodes[code_node_id.value];
+            return find_code_lang_in_css_class(code_node);
+        }
 
-        find_code_lang_in_css_class(code_node)
+        None
     }
 
     /// Transforms a `<pre>` code block, possibly with an associated language label that the resulting

--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -291,7 +291,9 @@ impl<'a> MDSerializer<'a> {
         if children.count() == 1 {
             let code_node_id = pre_node.first_child?;
             let code_node = &self.nodes[code_node_id.value];
-            return find_code_lang_in_css_class(code_node);
+            if code_node.as_element()?.name.local == local_name!("code") {
+                return find_code_lang_in_css_class(code_node);
+            }
         }
 
         None
@@ -577,14 +579,10 @@ fn add_linebreaks(text: &mut StrTendril, linebreak: &str, end: &str) {
 
 fn find_code_lang_in_css_class(node: &TreeNode) -> Option<String> {
     let tag_class = node.as_element()?.class()?;
-    tag_class.split_ascii_whitespace().find_map(|style| {
-        if style.starts_with("language-") {
-            let style = style.replacen("language-", "", 1);
-            Some(style)
-        } else {
-            None
-        }
-    })
+    tag_class
+        .split_ascii_whitespace()
+        .find_map(|style| style.strip_prefix("language-"))
+        .map(|lang| lang.to_string())
 }
 
 fn find_code_lang_attribute(node: &TreeNode) -> Option<String> {


### PR DESCRIPTION
When the language is specified as a CSS class with pattern `language-*`, it will be detected now. This is checked when the custom data attribute (e.g. `data-language`) was not found first.

Articles and websites specifiy the code language differently, one approach is to use a language CSS style in the `class` attribute, either as part of the `<pre>` block itself or more commonly in the single nested `<code>` block:

```html
<pre>
  <code class="language-rust">
    ...
  </code>
</pre>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks now detect language from CSS classes (language-xxx) on pre or nested code tags, with a fallback to existing detection—improves language annotation and highlighting.

* **Tests**
  * Added tests verifying language extraction from CSS classes on nested code tags within pre blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->