### PR TITLE
switch to ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/rust-arm64.yml
+++ b/.github/workflows/rust-arm64.yml
@@ -1,4 +1,4 @@
-name: Raspberry Pi 5 CI
+name: Rust CI ARM64
 
 on:
   push:
@@ -11,12 +11,13 @@ env:
 
 jobs:
   test:
-
-    runs-on: [self-hosted, linux, arm64]
-
+    runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
     - name: Run tests
-      run: cargo test --all-targets
+      run: cargo test
     - name: Run tests with all features
-      run: cargo test --all-targets --all-features
+      run: cargo test --all-features


### PR DESCRIPTION
switch to ubuntu-24.04-arm hosted runner instead of raspberrypi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes in this release.**

* **Chores**
  * Updated CI/CD infrastructure configuration for improved build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->