### PR TITLE
refactor(markdown): improve code organization.

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install wasm-bindgen-cli
       uses: taiki-e/install-action@v2
       with:
-        tool: wasm-bindgen-cli
+        tool: wasm-bindgen-cli@0.2.117
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the `dom_query` crate will be documented in this file.
 
 ### Changed
 - Applied selected Clippy suggestions (pedantic and nursery) to improve code quality. 
+- **Markdown**: moved `NodeRef::md` and `Document::md` implementations to a dedicated `serializing/md` 
+submodule to improve code organization. No public API changes.
 
 ## [0.27.0] - 2026-03-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1030,18 +1030,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1072,15 +1072,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1030,18 +1030,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.68"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
 dependencies = [
  "async-trait",
  "cast",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.68"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1072,15 +1072,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bit-set = "0.8.0"
 nom = {version = "8.0.0", optional = true}
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.68"
+wasm-bindgen-test = "=0.3.67"
 alloc_cat = "=1.0.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bit-set = "0.8.0"
 nom = {version = "8.0.0", optional = true}
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.67"
+wasm-bindgen-test = "0.3.68"
 alloc_cat = "=1.0.0"
 
 [features]

--- a/src/document.rs
+++ b/src/document.rs
@@ -509,15 +509,3 @@ fn append_to_existing_text(prev: &NodeRef, text: &StrTendril) -> bool {
         })
         .unwrap_or(false)
 }
-
-#[cfg(feature = "markdown")]
-impl Document {
-    /// Produces a *Markdown* representation of the [`Document`],  
-    /// skipping elements matching the specified `skip_tags` list along with their descendants.  
-    ///  
-    /// - If `skip_tags` is `None`, the default list is used: `["script", "style", "meta", "head"]`.  
-    /// - To process all elements without exclusions, pass `Some(&[])`.
-    pub fn md(&self, skip_tags: Option<&[&str]>) -> StrTendril {
-        self.root().md(skip_tags)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod matcher;
 mod node;
 mod selection;
 
+#[cfg(feature = "markdown")]
 pub mod serializing;
 
 #[cfg(feature = "mini_selector")]

--- a/src/mini_selector.rs
+++ b/src/mini_selector.rs
@@ -1,5 +1,5 @@
 //! A mini CSS selector parser and matcher.
-//! 
+//!
 //! This module provides a minimal CSS selector parser and matcher that supports a subset of the CSS selector syntax.
 
 mod extension;

--- a/src/node/node_ref.rs
+++ b/src/node/node_ref.rs
@@ -863,15 +863,3 @@ impl<'a> NodeRef<'a> {
         })
     }
 }
-
-#[cfg(feature = "markdown")]
-impl NodeRef<'_> {
-    /// Produces a *Markdown* representation of the node and its descendants,  
-    /// skipping elements matching the specified `skip_tags` list along with their descendants.  
-    ///  
-    /// - If `skip_tags` is `None`, the default list is used: `["script", "style", "meta", "head"]`.  
-    /// - To process all elements without exclusions, pass `Some(&[])`.
-    pub fn md(&self, skip_tags: Option<&[&str]>) -> StrTendril {
-        crate::serializing::serialize_md(self, false, skip_tags)
-    }
-}

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -628,7 +628,6 @@ impl<'a> Selection<'a> {
             Matches::new(self.nodes.clone().into_iter().rev(), matcher).next()
         };
         node.map_or_else(Selection::default, Selection::from)
-        
     }
 
     /// Gets the descendants of each element in the current set of matched elements, filter by a selector.

--- a/src/serializing.rs
+++ b/src/serializing.rs
@@ -1,8 +1,4 @@
 //! This module provides serialization functions. Currently contains only markdown serialization.
-//! 
+//!
 
-#[cfg(feature = "markdown")]
 mod md;
-
-#[cfg(feature = "markdown")]
-pub(crate) use md::serialize_md;

--- a/src/serializing/md.rs
+++ b/src/serializing/md.rs
@@ -1,4 +1,5 @@
 mod constants;
+mod ext;
 mod serializer;
 mod text_utils;
 

--- a/src/serializing/md/ext.rs
+++ b/src/serializing/md/ext.rs
@@ -1,0 +1,26 @@
+use tendril::StrTendril;
+
+use crate::{Document, NodeRef};
+use super::serialize_md;
+
+impl NodeRef<'_> {
+    /// Produces a *Markdown* representation of the node and its descendants,  
+    /// skipping elements matching the specified `skip_tags` list along with their descendants.  
+    ///  
+    /// - If `skip_tags` is `None`, the default list is used: `["script", "style", "meta", "head"]`.  
+    /// - To process all elements without exclusions, pass `Some(&[])`.
+    pub fn md(&self, skip_tags: Option<&[&str]>) -> StrTendril {
+        serialize_md(self, false, skip_tags)
+    }
+}
+
+impl Document {
+    /// Produces a *Markdown* representation of the [`Document`],  
+    /// skipping elements matching the specified `skip_tags` list along with their descendants.  
+    ///  
+    /// - If `skip_tags` is `None`, the default list is used: `["script", "style", "meta", "head"]`.  
+    /// - To process all elements without exclusions, pass `Some(&[])`.
+    pub fn md(&self, skip_tags: Option<&[&str]>) -> StrTendril {
+        self.root().md(skip_tags)
+    }
+}


### PR DESCRIPTION
- **Markdown**: moved `NodeRef::md` and `Document::md` implementations to a dedicated `serializing/md` 
submodule to improve code organization. No public API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized Markdown serialization implementation into a dedicated submodule structure for improved maintainability.

* **Style**
  * Minor documentation formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->