### PR TITLE
Preserve namespace when renaming elements

### DIFF
--- a/src/node/node_data.rs
+++ b/src/node/node_data.rs
@@ -258,8 +258,7 @@ impl Element {
 
     /// Renames the element.
     pub fn rename(&mut self, name: &str) {
-        let new_name = QualName::new(None, ns!(), LocalName::from(name));
-        self.name = new_name;
+        self.name.local = LocalName::from(name);
     }
 
     /// If element is a link.

--- a/tests/node-manipulation.rs
+++ b/tests/node-manipulation.rs
@@ -659,7 +659,10 @@ fn test_node_rename() {
     let sel = doc.select("#parent div");
     assert_eq!(sel.length(), 2);
     let node = sel.nodes().first().unwrap();
+    assert_eq!(node.qual_name_ref().unwrap().ns, ns!(html));
     node.rename("p");
+    assert_eq!(node.qual_name_ref().unwrap().ns, ns!(html));
+    assert!(node.html().starts_with("<p"));
     assert_eq!(doc.select("#parent div").length(), 1);
     assert_eq!(doc.select("#parent p").length(), 1);
     doc.tree.validate().unwrap();

--- a/tests/pseudo-classes.rs
+++ b/tests/pseudo-classes.rs
@@ -175,7 +175,7 @@ fn pseudo_class_only_text() {
     // this selector must ignore empty elements and elements that contains only whitespace
     // in this example the previous node of div with `Only text` is not empty,
     // it contains whitespace characters, so it will be ignored
-    assert!(sel.length() == 1);
+    assert_eq!(sel.length(), 1);
     assert_eq!(&sel.inner_html(), "Only text");
 }
 

--- a/tests/selection-traversal.rs
+++ b/tests/selection-traversal.rs
@@ -148,7 +148,7 @@ fn test_nth_child() {
     let a = doc
         .select("body > div.container.container-main > div.row:nth-child(2) > div.col-md-10 > a");
 
-    assert!(a.length() == 1);
+    assert_eq!(a.length(), 1);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -356,7 +356,7 @@ fn test_ancestors_with_limit() {
     let ancestors = child_node.ancestors(Some(2));
 
     // got 2 ancestors
-    assert!(ancestors.len() == 2);
+    assert_eq!(ancestors.len(), 2);
 
     let ancestor_sel = Selection::from(ancestors);
 
@@ -378,7 +378,7 @@ fn test_ancestor_iter_with_limit() {
     let ancestors = child_node.ancestors_it(Some(2));
     // utilizing ancestors iterator (without intermediate collection)
     // got 2 ancestors
-    assert!(ancestors.count() == 2);
+    assert_eq!(ancestors.count(), 2);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), test)]


### PR DESCRIPTION
Preserve an element’s existing namespace when renaming it to prevent incorrect HTML serialization.
A regression test verifies that the HTML namespace remains unchanged after renaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renaming an element now preserves its existing namespace and prefix.
  - Updated element names serialize correctly, including expected HTML markup.

- **Tests**
  - Expanded coverage to verify namespace preservation and serialized output after renaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->